### PR TITLE
feat/removing token reserves as bonding curve argument

### DIFF
--- a/src/LivoLaunchpad.sol
+++ b/src/LivoLaunchpad.sol
@@ -415,9 +415,8 @@ contract LivoLaunchpad is Ownable {
         ethFee = (ethValue * tokenConfig.buyFeeBps) / BASIS_POINTS;
         ethForPurchase = ethValue - ethFee;
 
-        tokensToReceive = tokenConfig.bondingCurve.buyTokensWithExactEth(
-            tokenStates[token].tokenReserves(), tokenStates[token].ethCollected, ethForPurchase
-        );
+        tokensToReceive =
+            tokenConfig.bondingCurve.buyTokensWithExactEth(tokenStates[token].ethCollected, ethForPurchase);
 
         return (ethForPurchase, ethFee, tokensToReceive);
     }
@@ -429,9 +428,7 @@ contract LivoLaunchpad is Ownable {
     {
         TokenConfig storage tokenConfig = tokenConfigs[token];
 
-        ethFromSale = tokenConfig.bondingCurve.sellExactTokens(
-            tokenStates[token].tokenReserves(), tokenStates[token].ethCollected, tokenAmount
-        );
+        ethFromSale = tokenConfig.bondingCurve.sellExactTokens(tokenStates[token].ethCollected, tokenAmount);
 
         ethFee = (ethFromSale * tokenConfig.sellFeeBps) / BASIS_POINTS;
         ethForSeller = ethFromSale - ethFee;

--- a/src/bondingCurves/ConstantProductBondingCurve.sol
+++ b/src/bondingCurves/ConstantProductBondingCurve.sol
@@ -29,7 +29,7 @@ contract ConstantProductBondingCurve is ILivoBondingCurve {
     error NotImplemented();
 
     /// @notice how many tokens can be purchased with a given amount of ETH
-    function buyTokensWithExactEth(uint256, /*tokenReserves*/ uint256 ethReserves, uint256 ethAmount)
+    function buyTokensWithExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         pure
         returns (uint256 tokensReceived)
@@ -45,11 +45,7 @@ contract ConstantProductBondingCurve is ILivoBondingCurve {
     }
 
     /// @notice how much ETH is required to buy an exact amount of tokens
-    function buyExactTokens(uint256, /*tokenReserves*/ uint256 ethReserves, uint256 tokenAmount)
-        external
-        pure
-        returns (uint256 ethRequired)
-    {
+    function buyExactTokens(uint256 ethReserves, uint256 tokenAmount) external pure returns (uint256 ethRequired) {
         // This would be the formula to implement, but not needed for this version.
         // uint256 tokenReserves = K / (ethReserves + E0) - T0;
         // ethRequired = K / (tokenReserves + T0 - tokenAmount) - ethReserves - E0;
@@ -58,11 +54,7 @@ contract ConstantProductBondingCurve is ILivoBondingCurve {
     }
 
     /// @notice how much ETH will be received when selling an exact amount of tokens
-    function sellExactTokens(uint256, /*tokenReserves*/ uint256 ethReserves, uint256 tokenAmount)
-        external
-        pure
-        returns (uint256 ethReceived)
-    {
+    function sellExactTokens(uint256 ethReserves, uint256 tokenAmount) external pure returns (uint256 ethReceived) {
         // The final expression is derived from these two:
         //      uint256 tokenReserves = K / (ethReserves + E0) - T0;
         //      ethReceived = E0 + ethReserves - K / (tokenReserves + tokenAmount + T0);
@@ -71,7 +63,7 @@ contract ConstantProductBondingCurve is ILivoBondingCurve {
     }
 
     /// @notice how many tokens need to be sold to receive an exact amount of ETH
-    function sellTokensForExactEth(uint256, /*tokenReserves*/ uint256 ethReserves, uint256 ethAmount)
+    function sellTokensForExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         pure
         returns (uint256 tokensRequired)

--- a/src/bondingCurves/DummyConstantPriceCurve.sol
+++ b/src/bondingCurves/DummyConstantPriceCurve.sol
@@ -14,7 +14,7 @@ contract DummyConstantPriceCurve is ILivoBondingCurve {
 
     event PriceSet(uint256 price);
 
-    function buyTokensWithExactEth(uint256 tokenReserves, uint256 ethReserves, uint256 ethAmount)
+    function buyTokensWithExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         view
         returns (uint256 tokensReceived)
@@ -22,23 +22,15 @@ contract DummyConstantPriceCurve is ILivoBondingCurve {
         return (PRECISION * ethAmount) / tokenPrice;
     }
 
-    function buyExactTokens(uint256 tokenReserves, uint256 ethReserves, uint256 tokenAmount)
-        external
-        view
-        returns (uint256 ethRequired)
-    {
+    function buyExactTokens(uint256 ethReserves, uint256 tokenAmount) external view returns (uint256 ethRequired) {
         return tokenAmount * tokenPrice / PRECISION;
     }
 
-    function sellExactTokens(uint256 tokenReserves, uint256 ethReserves, uint256 tokenAmount)
-        external
-        view
-        returns (uint256 ethReceived)
-    {
+    function sellExactTokens(uint256 ethReserves, uint256 tokenAmount) external view returns (uint256 ethReceived) {
         return tokenAmount * tokenPrice / PRECISION;
     }
 
-    function sellTokensForExactEth(uint256 tokenReserves, uint256 ethReserves, uint256 ethAmount)
+    function sellTokensForExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         view
         returns (uint256 tokensRequired)

--- a/src/interfaces/ILivoBondingCurve.sol
+++ b/src/interfaces/ILivoBondingCurve.sol
@@ -3,25 +3,19 @@ pragma solidity 0.8.28;
 
 interface ILivoBondingCurve {
     /// @notice how many tokens can be purchased with a given amount of ETH
-    function buyTokensWithExactEth(uint256 tokenReserves, uint256 ethReserves, uint256 ethAmount)
+    function buyTokensWithExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         view
         returns (uint256 tokensReceived);
 
     /// @notice how much ETH is required to buy an exact amount of tokens
-    function buyExactTokens(uint256 tokenReserves, uint256 ethReserves, uint256 tokenAmount)
-        external
-        view
-        returns (uint256 ethRequired);
+    function buyExactTokens(uint256 ethReserves, uint256 tokenAmount) external view returns (uint256 ethRequired);
 
     /// @notice how much ETH will be received when selling an exact amount of tokens
-    function sellExactTokens(uint256 tokenReserves, uint256 ethReserves, uint256 tokenAmount)
-        external
-        view
-        returns (uint256 ethReceived);
+    function sellExactTokens(uint256 ethReserves, uint256 tokenAmount) external view returns (uint256 ethReceived);
 
     /// @notice how many tokens need to be sold to receive an exact amount of ETH
-    function sellTokensForExactEth(uint256 tokenReserves, uint256 ethReserves, uint256 ethAmount)
+    function sellTokensForExactEth(uint256 ethReserves, uint256 ethAmount)
         external
         view
         returns (uint256 tokensRequired);

--- a/src/types/tokenData.sol
+++ b/src/types/tokenData.sol
@@ -43,6 +43,7 @@ library TokenDataLib {
         return !state.graduated;
     }
 
+    // todo this function is no longer used and probably can be removed
     function tokenReserves(TokenState storage state) internal view returns (uint256) {
         return TOTAL_SUPPLY - state.releasedSupply;
     }

--- a/test/bondingCurves/constantProductCurve.t.sol
+++ b/test/bondingCurves/constantProductCurve.t.sol
@@ -45,7 +45,7 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 ethReserves = 0;
         uint256 ethAmount = 1;
 
-        uint256 tokens = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
+        uint256 tokens = curve.buyTokensWithExactEth(ethReserves, ethAmount);
         assertTrue(tokens > 0, "Should mint non-zero amount of tokens");
     }
 
@@ -55,8 +55,8 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 tokenReserves = curve.getTokenReserves(ethReserves);
         uint256 ethAmount = 1e18;
 
-        uint256 tokensReceived = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
-        uint256 ethRequired = curve.buyExactTokens(tokenReserves, ethReserves, tokensReceived);
+        uint256 tokensReceived = curve.buyTokensWithExactEth(ethReserves, ethAmount);
+        uint256 ethRequired = curve.buyExactTokens(ethReserves, tokensReceived);
 
         // accept a difference of 0.01% between the two functions
         assertApproxEqRel(ethRequired, ethAmount, 0.0001e18, "Buy functions should match in price");
@@ -68,7 +68,7 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 ethReserves = GRADUATION_THRESHOLD;
         // the buy value cannot be too hight, otherwise we affect the price too much
         uint256 buyValue = 0.000001e18;
-        uint256 tokensReceived = curve.buyTokensWithExactEth(tokenReserves, ethReserves, buyValue);
+        uint256 tokensReceived = curve.buyTokensWithExactEth(ethReserves, buyValue);
         uint256 curvePrice = (1e18 * buyValue) / tokensReceived; // ETH/tokens
 
         // then we take the graduation fee and tokens for creators, and calculate the Uniswap price
@@ -86,7 +86,7 @@ contract ConstantProductBondingCurveTest is Test {
         ethAmount = bound(ethAmount, 0, 37e18);
 
         // token reserves are calculated internally from the ethReserves so it doesn't matter what we pass here
-        uint256 tokensReceived = curve.buyTokensWithExactEth(1, ethReserves, ethAmount);
+        uint256 tokensReceived = curve.buyTokensWithExactEth(ethReserves, ethAmount);
     }
 
     // This basically tests that a buy can happen after the first small purchase. Not the most useful test though.
@@ -95,7 +95,7 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 tokenReserves = curve.getTokenReserves(ethReserves);
         uint256 tokenAmount = 1000e18;
 
-        uint256 ethReceived = curve.sellExactTokens(tokenReserves, ethReserves, tokenAmount);
+        uint256 ethReceived = curve.sellExactTokens(ethReserves, tokenAmount);
         assertTrue(ethReceived > 0, "Should receive non-zero amount of ETH");
     }
 
@@ -103,7 +103,7 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 tokenReserves = curve.getTokenReserves(GRADUATION_THRESHOLD);
         uint256 ethReserves = GRADUATION_THRESHOLD;
         uint256 sellAmount = 1000e18;
-        uint256 ethReceived = curve.sellExactTokens(tokenReserves, ethReserves, sellAmount);
+        uint256 ethReceived = curve.sellExactTokens(ethReserves, sellAmount);
         uint256 curvePrice = (1e18 * ethReceived) / sellAmount;
 
         uint256 tokenReservesForUniswap = tokenReserves - GRADUATION_TOKEN_CREATOR_REWARD;
@@ -118,7 +118,7 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 tokenReserves = curve.getTokenReserves(ethReserves);
         tokenAmount = bound(tokenAmount, 1e18, tokenReserves / 10);
 
-        uint256 ethReceived = curve.sellExactTokens(tokenReserves, ethReserves, tokenAmount);
+        uint256 ethReceived = curve.sellExactTokens(ethReserves, tokenAmount);
         assertTrue(ethReceived > 0, "Should receive ETH when selling tokens");
     }
 
@@ -127,13 +127,13 @@ contract ConstantProductBondingCurveTest is Test {
         uint256 tokenReserves = curve.getTokenReserves(ethReserves);
 
         ethAmount = bound(ethAmount, 0.000001e18, 2e18);
-        uint256 tokensReceived = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
+        uint256 tokensReceived = curve.buyTokensWithExactEth(ethReserves, ethAmount);
         ethReserves += ethAmount;
         console.log("before updating tokenReserves");
         tokenReserves -= tokensReceived;
         console.log("after updating tokenReserves");
 
-        uint256 ethReceived = curve.sellExactTokens(tokenReserves, ethReserves, tokensReceived);
+        uint256 ethReceived = curve.sellExactTokens(ethReserves, tokensReceived);
 
         // we accept a loss of up to 0.1% in the buy+sell process
         assertApproxEqRel(ethReceived, ethAmount, 0.00000001e18, "Should get back almost all ETH after buy+sell");

--- a/test/bondingCurves/dummyConstantPriceCurve.t.sol
+++ b/test/bondingCurves/dummyConstantPriceCurve.t.sol
@@ -22,7 +22,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 0;
         uint256 ethReserves = 0;
 
-        uint256 tokens = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
+        uint256 tokens = curve.buyTokensWithExactEth(ethReserves, ethAmount);
         assertEq(tokens, 1 ether);
     }
 
@@ -31,7 +31,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 1000e18;
         uint256 ethReserves = 0;
 
-        uint256 tokens = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
+        uint256 tokens = curve.buyTokensWithExactEth(ethReserves, ethAmount);
         assertEq(tokens, 1 ether);
     }
 
@@ -40,7 +40,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 0;
         uint256 ethReserves = 0;
 
-        uint256 tokens = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
+        uint256 tokens = curve.buyTokensWithExactEth(ethReserves, ethAmount);
         assertEq(tokens, 0);
     }
 
@@ -49,7 +49,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 0;
         uint256 ethReserves = 0;
 
-        uint256 ethRequired = curve.buyExactTokens(tokenReserves, ethReserves, tokenAmount);
+        uint256 ethRequired = curve.buyExactTokens(ethReserves, tokenAmount);
         assertEq(ethRequired, 1e10);
     }
 
@@ -58,7 +58,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 500e18;
         uint256 ethReserves = 0;
 
-        uint256 ethRequired = curve.buyExactTokens(tokenReserves, ethReserves, tokenAmount);
+        uint256 ethRequired = curve.buyExactTokens(ethReserves, tokenAmount);
         assertEq(ethRequired, 1e10);
     }
 
@@ -67,7 +67,7 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 0;
         uint256 ethReserves = 0;
 
-        uint256 ethRequired = curve.buyExactTokens(tokenReserves, ethReserves, tokenAmount);
+        uint256 ethRequired = curve.buyExactTokens(ethReserves, tokenAmount);
         assertEq(ethRequired, 0);
     }
 
@@ -76,8 +76,8 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 tokenReserves = 100e18;
         uint256 ethReserves = 0;
 
-        uint256 tokens = curve.buyTokensWithExactEth(tokenReserves, ethReserves, ethAmount);
-        uint256 ethBack = curve.buyExactTokens(tokenReserves, ethReserves, tokens);
+        uint256 tokens = curve.buyTokensWithExactEth(ethReserves, ethAmount);
+        uint256 ethBack = curve.buyExactTokens(ethReserves, tokens);
 
         assertEq(ethBack, ethAmount);
     }
@@ -86,9 +86,9 @@ contract DummyConstantPriceCurveTest is Test {
         uint256 ethAmount = 1 ether;
         uint256 ethReserves = 0;
 
-        uint256 tokens1 = curve.buyTokensWithExactEth(0, ethReserves, ethAmount);
-        uint256 tokens2 = curve.buyTokensWithExactEth(1000e18, ethReserves, ethAmount);
-        uint256 tokens3 = curve.buyTokensWithExactEth(1e24, ethReserves, ethAmount);
+        uint256 tokens1 = curve.buyTokensWithExactEth(ethReserves, ethAmount);
+        uint256 tokens2 = curve.buyTokensWithExactEth(ethReserves, ethAmount);
+        uint256 tokens3 = curve.buyTokensWithExactEth(ethReserves, ethAmount);
 
         assertEq(tokens1, tokens2);
         assertEq(tokens2, tokens3);

--- a/test/bondingCurves/priceSimulations.p.sol
+++ b/test/bondingCurves/priceSimulations.p.sol
@@ -50,7 +50,7 @@ contract ConstantProductPriceSimulations is Test {
         for (uint256 ethReserves = startEthReserves; ethReserves <= endEthReserves; ethReserves += 0.01e18) {
             uint256 tokenReserves = bondingCurve.getTokenReserves(ethReserves);
             uint256 ethValue = 0.001e18;
-            uint256 tokensReceived = bondingCurve.buyTokensWithExactEth(tokenReserves, ethReserves, ethValue);
+            uint256 tokensReceived = bondingCurve.buyTokensWithExactEth(ethReserves, ethValue);
             uint256 buyPrice = 10e18 * ethValue / tokensReceived; // ETH/tokens
             uint256 univ2price = 10e18 * (ethReserves - ethFee) / (tokenReserves - creatorSupply); // ETH/tokens
             uint256 priceStep = (univ2price - buyPrice) * 1e18 / buyPrice;


### PR DESCRIPTION
- **feat: removed tokenReserves argument from interface and the two bonding curves implementations**
- **tests: updated all tests to the new function signatures without tokenReserves**
