### PR TITLE
feat/separate factoryv2

### DIFF
--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -191,8 +191,7 @@ contract Deployments is Script {
             address(livoToken),
             address(bondingCurve),
             address(graduatorV2),
-            address(feeHandler),
-            address(feeSplitterImpl)
+            address(feeHandler)
         );
         console.log("| LivoFactoryUniV2 (V2) | ", address(factoryV2));
         LivoFactoryBase factoryV4 = new LivoFactoryBase(

--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -186,13 +186,8 @@ contract Deployments is Script {
         console.log("| LivoFeeSplitter (impl) | ", address(feeSplitterImpl));
 
         // 10. Deploy factories
-        LivoFactoryUniV2 factoryV2 = new LivoFactoryUniV2(
-            address(launchpad),
-            address(livoToken),
-            address(bondingCurve),
-            address(graduatorV2),
-            address(feeHandler)
-        );
+        LivoFactoryUniV2 factoryV2 =
+            new LivoFactoryUniV2(address(launchpad), address(livoToken), address(bondingCurve), address(graduatorV2));
         console.log("| LivoFactoryUniV2 (V2) | ", address(factoryV2));
         LivoFactoryBase factoryV4 = new LivoFactoryBase(
             address(launchpad),

--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -9,6 +9,7 @@ import {LivoGraduatorUniswapV2} from "src/graduators/LivoGraduatorUniswapV2.sol"
 import {LivoGraduatorUniswapV4} from "src/graduators/LivoGraduatorUniswapV4.sol";
 import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
 import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {LivoFactoryTaxToken} from "src/factories/LivoFactoryTaxToken.sol";
 import {LivoFeeHandler} from "src/feeHandlers/LivoFeeHandler.sol";
 import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
@@ -185,7 +186,7 @@ contract Deployments is Script {
         console.log("| LivoFeeSplitter (impl) | ", address(feeSplitterImpl));
 
         // 10. Deploy factories
-        LivoFactoryBase factoryV2 = new LivoFactoryBase(
+        LivoFactoryUniV2 factoryV2 = new LivoFactoryUniV2(
             address(launchpad),
             address(livoToken),
             address(bondingCurve),
@@ -193,7 +194,7 @@ contract Deployments is Script {
             address(feeHandler),
             address(feeSplitterImpl)
         );
-        console.log("| LivoFactory (V2) | ", address(factoryV2));
+        console.log("| LivoFactoryUniV2 (V2) | ", address(factoryV2));
         LivoFactoryBase factoryV4 = new LivoFactoryBase(
             address(launchpad),
             address(livoToken),

--- a/script/sepoliaSimulations/launchAndPurchases.s.sol
+++ b/script/sepoliaSimulations/launchAndPurchases.s.sol
@@ -24,7 +24,7 @@ contract BuySellSimulations is Script {
         vm.startBroadcast();
         bytes32 salt = bytes32(uint256(0x123));
 
-        address TOKEN1 = factoryV2.createToken("MEMEV2", "MAMIV2", LIVODEV, salt);
+        address TOKEN1 = factoryV2.createToken("MEMEV2", "MAMIV2", salt);
         address TOKEN2 = factoryV4.createToken("projecTV4", "PROJECTV4", LIVODEV, salt);
         address TOKEN3 = factoryTax.createToken("projecTaxTV4", "PROJECTAXV4", LIVODEV, salt, 0, 500, uint32(14 days));
 

--- a/script/sepoliaSimulations/launchAndPurchases.s.sol
+++ b/script/sepoliaSimulations/launchAndPurchases.s.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
 import {LivoFactoryTaxToken} from "src/factories/LivoFactoryTaxToken.sol";
 import {Script} from "lib/forge-std/src/Script.sol";
@@ -16,7 +17,7 @@ contract BuySellSimulations is Script {
         address factoryTaxAddress = vm.envAddress("FACTORY_TAX");
 
         LivoLaunchpad launchpad = LivoLaunchpad(launchpadAddress);
-        LivoFactoryBase factoryV2 = LivoFactoryBase(factoryV2Address);
+        LivoFactoryUniV2 factoryV2 = LivoFactoryUniV2(factoryV2Address);
         LivoFactoryBase factoryV4 = LivoFactoryBase(factoryV4Address);
         LivoFactoryTaxToken factoryTax = LivoFactoryTaxToken(factoryTaxAddress);
 

--- a/src/factories/LivoFactoryUniV2.sol
+++ b/src/factories/LivoFactoryUniV2.sol
@@ -9,40 +9,28 @@ import {LivoFactoryAbstract} from "src/factories/LivoFactoryAbstract.sol";
 
 /// @notice Factory for deploying standard Livo tokens on Uniswap V2 with ownership renounced at creation
 contract LivoFactoryUniV2 is LivoFactoryAbstract {
-    constructor(
-        address launchpad,
-        address tokenImplementation,
-        address bondingCurve,
-        address graduator,
-        address feeHandler
-    )
-        LivoFactoryAbstract(
-            launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, address(0)
-        )
+    constructor(address launchpad, address tokenImplementation, address bondingCurve, address graduator)
+        LivoFactoryAbstract(launchpad, tokenImplementation, bondingCurve, graduator, address(0), address(0))
     {}
 
     /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
 
     /// @notice Deploys a new token clone with ownership renounced, initializes it, and registers it in the launchpad
-    function createToken(string calldata name, string calldata symbol, address feeReceiver, bytes32 salt)
+    function createToken(string calldata name, string calldata symbol, bytes32 salt)
         external
         payable
         returns (address token)
     {
-        require(feeReceiver != address(0), InvalidFeeReceiver());
-        token = _createAndInitializeToken(name, symbol, address(FEE_HANDLER), feeReceiver, salt);
+        token = _createAndInitializeToken(name, symbol, salt);
         if (msg.value > 0) _buyOnBehalf(token);
     }
 
     ///////////////////////// INTERNAL FUNCTIONS /////////////////////////
 
-    function _createAndInitializeToken(
-        string calldata name,
-        string calldata symbol,
-        address feeHandler_,
-        address feeReceiver,
-        bytes32 salt
-    ) internal returns (address token) {
+    function _createAndInitializeToken(string calldata name, string calldata symbol, bytes32 salt)
+        internal
+        returns (address token)
+    {
         require(bytes(name).length > 0 && bytes(symbol).length > 0, InvalidNameOrSymbol());
         require(bytes(symbol).length <= 32, InvalidNameOrSymbol());
 
@@ -54,20 +42,21 @@ contract LivoFactoryUniV2 is LivoFactoryAbstract {
         // creates the TokenData entity from this event, and events emitted during initialize()
         // (PairInitialized, PoolIdRegistered, etc.) depend on TokenData existing.
         emit TokenCreated(
-            token, name, symbol, address(0), address(LAUNCHPAD), address(GRADUATOR), feeHandler_, feeReceiver
+            token, name, symbol, address(0), address(LAUNCHPAD), address(GRADUATOR), address(0), address(0)
         );
 
-        LivoToken(token).initialize(
-            ILivoToken.InitializeParams({
-                name: name,
-                symbol: symbol,
-                tokenOwner: address(0),
-                graduator: address(GRADUATOR),
-                launchpad: address(LAUNCHPAD),
-                feeHandler: feeHandler_,
-                feeReceiver: feeReceiver
-            })
-        );
+        LivoToken(token)
+            .initialize(
+                ILivoToken.InitializeParams({
+                    name: name,
+                    symbol: symbol,
+                    tokenOwner: address(0),
+                    graduator: address(GRADUATOR),
+                    launchpad: address(LAUNCHPAD),
+                    feeHandler: address(0),
+                    feeReceiver: address(0)
+                })
+            );
 
         // registers token in launchpad. This will also emit an event from the launchpad
         LAUNCHPAD.launchToken(token, BONDING_CURVE);

--- a/src/factories/LivoFactoryUniV2.sol
+++ b/src/factories/LivoFactoryUniV2.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Clones} from "lib/openzeppelin-contracts/contracts/proxy/Clones.sol";
+
+import {ILivoToken} from "src/interfaces/ILivoToken.sol";
+import {LivoToken} from "src/tokens/LivoToken.sol";
+import {LivoFactoryAbstract} from "src/factories/LivoFactoryAbstract.sol";
+
+/// @notice Factory for deploying standard Livo tokens on Uniswap V2 with ownership renounced at creation
+contract LivoFactoryUniV2 is LivoFactoryAbstract {
+    constructor(
+        address launchpad,
+        address tokenImplementation,
+        address bondingCurve,
+        address graduator,
+        address feeHandler,
+        address feeSplitterImplementation
+    )
+        LivoFactoryAbstract(
+            launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, feeSplitterImplementation
+        )
+    {}
+
+    /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
+
+    /// @notice Deploys a new token clone with ownership renounced, initializes it, and registers it in the launchpad
+    function createToken(string calldata name, string calldata symbol, address feeReceiver, bytes32 salt)
+        external
+        payable
+        returns (address token)
+    {
+        require(feeReceiver != address(0), InvalidFeeReceiver());
+        token = _createAndInitializeToken(name, symbol, address(FEE_HANDLER), feeReceiver, salt);
+        if (msg.value > 0) _buyOnBehalf(token);
+    }
+
+    ///////////////////////// INTERNAL FUNCTIONS /////////////////////////
+
+    function _createAndInitializeToken(
+        string calldata name,
+        string calldata symbol,
+        address feeHandler_,
+        address feeReceiver,
+        bytes32 salt
+    ) internal returns (address token) {
+        require(bytes(name).length > 0 && bytes(symbol).length > 0, InvalidNameOrSymbol());
+        require(bytes(symbol).length <= 32, InvalidNameOrSymbol());
+
+        // minimal proxy pattern to deploy a new LivoToken instance
+        token = Clones.cloneDeterministic(address(_tokenImplementation), salt);
+        require(uint16(uint160(token)) == 0x1110, InvalidTokenAddress());
+
+        // IMPORTANT: TokenCreated must be emitted BEFORE initialize() because the indexer
+        // creates the TokenData entity from this event, and events emitted during initialize()
+        // (PairInitialized, PoolIdRegistered, etc.) depend on TokenData existing.
+        emit TokenCreated(
+            token, name, symbol, address(0), address(LAUNCHPAD), address(GRADUATOR), feeHandler_, feeReceiver
+        );
+
+        LivoToken(token).initialize(
+            ILivoToken.InitializeParams({
+                name: name,
+                symbol: symbol,
+                tokenOwner: address(0),
+                graduator: address(GRADUATOR),
+                launchpad: address(LAUNCHPAD),
+                feeHandler: feeHandler_,
+                feeReceiver: feeReceiver
+            })
+        );
+
+        // registers token in launchpad. This will also emit an event from the launchpad
+        LAUNCHPAD.launchToken(token, BONDING_CURVE);
+    }
+}

--- a/src/factories/LivoFactoryUniV2.sol
+++ b/src/factories/LivoFactoryUniV2.sol
@@ -14,11 +14,10 @@ contract LivoFactoryUniV2 is LivoFactoryAbstract {
         address tokenImplementation,
         address bondingCurve,
         address graduator,
-        address feeHandler,
-        address feeSplitterImplementation
+        address feeHandler
     )
         LivoFactoryAbstract(
-            launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, feeSplitterImplementation
+            launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, address(0)
         )
     {}
 

--- a/src/graduators/LivoGraduatorUniswapV2.sol
+++ b/src/graduators/LivoGraduatorUniswapV2.sol
@@ -12,12 +12,8 @@ import {IUniswapV2Pair} from "src/interfaces/IUniswapV2Pair.sol";
 contract LivoGraduatorUniswapV2 is ILivoGraduator {
     using SafeERC20 for ILivoToken;
 
-    /// @notice Graduation ETH fee split between creator and treasury
+    /// @notice Graduation ETH fee sent entirely to treasury
     uint256 public constant GRADUATION_ETH_FEE = 0.25 ether;
-
-    /// @notice ETH compensation paid to token creator at graduation
-    /// @dev this is part of the GRADUATION_ETH_FEE
-    uint256 public constant CREATOR_GRADUATION_COMPENSATION = 0.05 ether;
 
     /// @notice Where LP tokens are sent at graduation, effectively locking the liquidity
     address internal constant DEAD_ADDRESS = address(0xdEaD);
@@ -156,17 +152,12 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
         require(msg.value > GRADUATION_ETH_FEE, NotEnoughEthForGraduation());
 
         ethForLiquidity = msg.value - GRADUATION_ETH_FEE;
-        uint256 treasuryShare = GRADUATION_ETH_FEE - CREATOR_GRADUATION_COMPENSATION;
 
-        // Deposit creator compensation through the token
-        emit CreatorGraduationFeeCollected(tokenAddress, CREATOR_GRADUATION_COMPENSATION);
-        ILivoToken(tokenAddress).accrueFees{value: CREATOR_GRADUATION_COMPENSATION}();
-
-        // Send treasury share directly to treasury
+        // Send entire graduation fee to treasury
         address treasury = ILivoLaunchpad(LIVO_LAUNCHPAD).treasury();
-        (bool success,) = treasury.call{value: treasuryShare}("");
+        (bool success,) = treasury.call{value: GRADUATION_ETH_FEE}("");
         require(success, EtherTransferFailed());
-        emit TreasuryGraduationFeeCollected(tokenAddress, treasuryShare);
+        emit TreasuryGraduationFeeCollected(tokenAddress, GRADUATION_ETH_FEE);
     }
 
     function _cleanup(address tokenAddress) internal {

--- a/test/bondingCurves/priceImpactSimulations.p.sol
+++ b/test/bondingCurves/priceImpactSimulations.p.sol
@@ -20,9 +20,7 @@ contract ConstantProductPriceImpactSimulations is Test {
         // bps: 100 = 1.00%. Print as "X.YZ%" with 2 decimals.
         uint256 whole = bps / 100;
         uint256 frac = bps % 100;
-        string memory fracStr = frac < 10
-            ? string.concat("0", vm.toString(frac))
-            : vm.toString(frac);
+        string memory fracStr = frac < 10 ? string.concat("0", vm.toString(frac)) : vm.toString(frac);
         return string.concat(vm.toString(whole), ".", fracStr, "%");
     }
 

--- a/test/bondingCurves/priceImpactSimulations.p.sol
+++ b/test/bondingCurves/priceImpactSimulations.p.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
+import {ConstantProductBondingCurve} from "src/bondingCurves/ConstantProductBondingCurve.sol";
+
+contract ConstantProductPriceImpactSimulations is Test {
+    ConstantProductBondingCurve bondingCurve = new ConstantProductBondingCurve();
+
+    uint256 E0 = bondingCurve.E0();
+    uint256 K = bondingCurve.K();
+
+    function _estimateSpotPrice(uint256 ethReserves) internal view returns (uint256) {
+        // Closed-form spot price (ETH per token, 1e18-scaled): 1e18 * (ethReserves + E0)^2 / K
+        return 1e18 * (ethReserves + E0) ** 2 / K;
+    }
+
+    function _formatBpsAsPercent(uint256 bps) internal view returns (string memory) {
+        // bps: 100 = 1.00%. Print as "X.YZ%" with 2 decimals.
+        uint256 whole = bps / 100;
+        uint256 frac = bps % 100;
+        string memory fracStr = frac < 10
+            ? string.concat("0", vm.toString(frac))
+            : vm.toString(frac);
+        return string.concat(vm.toString(whole), ".", fracStr, "%");
+    }
+
+    function _logPriceImpact(uint256 buySize) internal view {
+        uint256 graduation = bondingCurve.ethGraduationThreshold();
+        uint256 maxReserves = bondingCurve.maxEthReserves();
+
+        console.log("reserves | currentPrice | priceAfterBuy | priceImpact");
+
+        for (uint256 ethReserves = 0; ethReserves <= graduation; ethReserves += 0.1 ether) {
+            if (ethReserves + buySize > maxReserves) break;
+
+            uint256 currentPrice = _estimateSpotPrice(ethReserves);
+            (uint256 tokensReceived,) = bondingCurve.buyTokensWithExactEth(ethReserves, buySize);
+            uint256 priceAfterBuy = 1e18 * buySize / tokensReceived;
+            uint256 priceImpactBps = (priceAfterBuy - currentPrice) * 10000 / currentPrice;
+
+            console.log(ethReserves, currentPrice, priceAfterBuy, _formatBpsAsPercent(priceImpactBps));
+        }
+    }
+
+    function test_priceImpact_0_1_eth() public {
+        vm.skip(true);
+        _logPriceImpact(0.1 ether);
+    }
+
+    function test_priceImpact_0_5_eth() public {
+        vm.skip(true);
+        _logPriceImpact(0.5 ether);
+    }
+
+    function test_priceImpact_1_eth() public {
+        vm.skip(true);
+        _logPriceImpact(1 ether);
+    }
+}

--- a/test/factories/LivoFactoryBase.t.sol
+++ b/test/factories/LivoFactoryBase.t.sol
@@ -34,7 +34,7 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
         assertEq(token.totalSupply(), TOTAL_SUPPLY);
         assertEq(token.balanceOf(address(launchpad)), TOTAL_SUPPLY);
         assertEq(token.graduator(), address(graduatorV2));
-        assertEq(token.owner(), creator);
+        assertEq(token.owner(), address(0));
 
         TokenConfig memory config = launchpad.getTokenConfig(deployedToken);
         assertEq(address(config.bondingCurve), address(bondingCurve));

--- a/test/factories/LivoFactoryBase.t.sol
+++ b/test/factories/LivoFactoryBase.t.sol
@@ -18,7 +18,7 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     modifier withCreatedToken() {
         vm.prank(creator);
         deployedToken =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+            factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         _;
     }
 
@@ -51,28 +51,21 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     function test_createToken_revertsOnEmptyName() public {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("", "TEST", creator, "0x12");
+        factoryV2.createToken("", "TEST", "0x12");
     }
 
     /// @dev when symbol is empty, then createToken reverts with InvalidNameOrSymbol
     function test_createToken_revertsOnEmptySymbol() public {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("TestToken", "", creator, "0x0");
+        factoryV2.createToken("TestToken", "", "0x0");
     }
 
     /// @dev when symbol exceeds 32 bytes, then createToken reverts with InvalidNameOrSymbol
     function test_createToken_revertsOnTooLongSymbol() public {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("TestToken", "TESTTESTTESTTESTTESTTESTTESTESESD", creator, "0x12");
-    }
-
-    /// @dev when feeReceiver is zero address, then createToken reverts with InvalidFeeReceiver
-    function test_createToken_revertsOnZeroFeeReceiver() public {
-        vm.prank(creator);
-        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidFeeReceiver.selector));
-        factoryV2.createToken("TestToken", "TEST", address(0), "0x12");
+        factoryV2.createToken("TestToken", "TESTTESTTESTTESTTESTTESTTESTESESD", "0x12");
     }
 
     /// @dev when implementation is initialized directly, then it reverts with InvalidInitialization
@@ -97,14 +90,12 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     /// @dev when two tokens share the same symbol, then both are created with different addresses
     function test_createToken_assertDuplicateSymbolsYieldDifferentAddresses() public {
         vm.prank(creator);
-        address token1 = factoryV2.createToken(
-            "TestToken1", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token1 =
+            factoryV2.createToken("TestToken1", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         vm.prank(creator);
-        address token2 = factoryV2.createToken(
-            "TestToken2", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token2 =
+            factoryV2.createToken("TestToken2", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(token1 != token2);
         assertEq(LivoToken(token1).symbol(), "TEST");
@@ -116,14 +107,12 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     /// @dev when tokens are created with different symbols, then both succeed with correct metadata
     function test_createToken_assertDifferentSymbolsBothSucceed() public {
         vm.prank(creator);
-        address token1 = factoryV2.createToken(
-            "TestToken1", "TEST1", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token1 =
+            factoryV2.createToken("TestToken1", "TEST1", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         vm.prank(creator);
-        address token2 = factoryV2.createToken(
-            "TestToken2", "TEST2", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token2 =
+            factoryV2.createToken("TestToken2", "TEST2", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(token1 != token2);
         assertEq(LivoToken(token1).symbol(), "TEST1");
@@ -151,7 +140,7 @@ contract LivoFactoryBaseDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
         }
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidTokenAddress.selector));
-        factoryV2.createToken("TestToken", "TEST", creator, badSalt);
+        factoryV2.createToken("TestToken", "TEST", badSalt);
     }
 }
 
@@ -172,7 +161,7 @@ contract LivoFactoryBaseWhitelistTest is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         address token =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+            factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         assertTrue(token != address(0));
     }
 
@@ -182,7 +171,7 @@ contract LivoFactoryBaseWhitelistTest is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(LivoLaunchpad.UnauthorizedFactory.selector));
-        factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+        factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
     }
 
     /// @dev when factory is blacklisted then re-whitelisted, then createToken succeeds again
@@ -192,7 +181,7 @@ contract LivoFactoryBaseWhitelistTest is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         address token =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+            factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         assertTrue(token != address(0));
     }
 

--- a/test/factories/LivoFactoryDeployerBuy.t.sol
+++ b/test/factories/LivoFactoryDeployerBuy.t.sol
@@ -23,7 +23,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
 
         vm.prank(creator);
-        address token = factoryV2.createToken{value: ethToSpend}("TestToken", "TEST", creator, salt);
+        address token = factoryV2.createToken{value: ethToSpend}("TestToken", "TEST", salt);
 
         // deployer received tokens
         uint256 creatorBalance = LivoToken(token).balanceOf(creator);
@@ -44,7 +44,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
 
         vm.prank(creator);
-        address token = factoryV2.createToken("TestToken", "TEST", creator, salt);
+        address token = factoryV2.createToken("TestToken", "TEST", salt);
 
         assertEq(LivoToken(token).balanceOf(creator), 0);
         assertEq(LivoToken(token).balanceOf(address(launchpad)), TOTAL_SUPPLY);
@@ -59,7 +59,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
 
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidDeployerBuy.selector));
-        factoryV2.createToken{value: 1 ether}("TestToken", "TEST", creator, salt);
+        factoryV2.createToken{value: 1 ether}("TestToken", "TEST", salt);
     }
 
     // ============ Events ============
@@ -72,7 +72,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         vm.prank(creator);
         vm.expectEmit(false, true, false, false);
         emit ILivoFactory.DeployerBuy(address(0), creator, 0, 0); // only check buyer indexed param
-        factoryV2.createToken{value: ethToSpend}("TestToken", "TEST", creator, salt);
+        factoryV2.createToken{value: ethToSpend}("TestToken", "TEST", salt);
     }
 
     // ============ Admin: setMaxDeployerBuyBps ============
@@ -100,7 +100,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
 
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidDeployerBuy.selector));
-        factoryV2.createToken{value: 0.01 ether}("TestToken", "TEST", creator, salt);
+        factoryV2.createToken{value: 0.01 ether}("TestToken", "TEST", salt);
     }
 
     /// @dev MaxDeployerBuyBpsUpdated event is emitted
@@ -121,7 +121,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
 
         vm.prank(creator);
-        address token = factoryV2.createToken{value: totalEthNeeded}("TestToken", "TEST", creator, salt);
+        address token = factoryV2.createToken{value: totalEthNeeded}("TestToken", "TEST", salt);
 
         uint256 creatorBalance = LivoToken(token).balanceOf(creator);
         assertGe(creatorBalance, tokenAmount);
@@ -135,7 +135,7 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
 
         vm.prank(creator);
-        address token = factoryV2.createToken{value: totalEthNeeded}("TestToken", "TEST", creator, salt);
+        address token = factoryV2.createToken{value: totalEthNeeded}("TestToken", "TEST", salt);
 
         uint256 creatorBalance = LivoToken(token).balanceOf(creator);
         assertGe(creatorBalance, maxTokens);

--- a/test/factories/LivoFactoryDeployerBuy.t.sol
+++ b/test/factories/LivoFactoryDeployerBuy.t.sol
@@ -39,26 +39,6 @@ contract LivoFactoryBaseDeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator 
         assertEq(state.releasedSupply, creatorBalance);
     }
 
-    /// @dev deployer can buy tokens with ETH during createTokenWithFeeSplit
-    function test_createTokenWithFeeSplit_deployerBuy() public {
-        uint256 ethToSpend = 0.1 ether;
-        bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
-
-        address[] memory recipients = new address[](1);
-        recipients[0] = creator;
-        uint256[] memory shares = new uint256[](1);
-        shares[0] = 10_000;
-
-        vm.prank(creator);
-        (address token,) =
-            factoryV2.createTokenWithFeeSplit{value: ethToSpend}("TestToken", "TEST", recipients, shares, salt);
-
-        uint256 creatorBalance = LivoToken(token).balanceOf(creator);
-        assertGt(creatorBalance, 0);
-        assertLe(creatorBalance, TOTAL_SUPPLY * 1_000 / 10_000);
-        assertEq(LivoToken(token).balanceOf(address(factoryV2)), 0);
-    }
-
     /// @dev createToken with msg.value=0 still works (backward compatible)
     function test_createToken_noEth_backwardCompatible() public {
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));

--- a/test/graduators/graduation.t.sol
+++ b/test/graduators/graduation.t.sol
@@ -58,7 +58,7 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
     }
 
     /// @notice creator gets the CREATOR_GRADUATION_COMPENSATION at graduation
-    function test_creatorGetsGraduationCompensation() public createTestToken {
+    function test_creatorGetsGraduationCompensation() public virtual createTestToken {
         ILivoFeeHandler tokenFeeHandler = _tokenFeeHandler();
 
         address[] memory _tokens = new address[](1);
@@ -127,7 +127,7 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
     }
 
     /// @notice Test that at graduation the team collects the graduation fee in eth (sent directly to treasury)
-    function test_teamCollectsGraduationFeeInEthAtGraduation() public createTestToken {
+    function test_teamCollectsGraduationFeeInEthAtGraduation() public virtual createTestToken {
         uint256 treasuryBalanceBefore = treasury.balance;
 
         // Calculate the ETH that will be spent to graduate (for trading fee calculation)
@@ -227,7 +227,7 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
     }
 
     /// @notice Test that eth treasury balance change at graduation is the graduation fee or larger (including the trading fee)
-    function test_treasuryEthBalanceChangeAtGraduationAccountsForGraduationFee() public createTestToken {
+    function test_treasuryEthBalanceChangeAtGraduationAccountsForGraduationFee() public virtual createTestToken {
         vm.deal(buyer, 100 ether);
 
         uint256 treasuryEthBefore = treasury.balance;
@@ -323,8 +323,61 @@ contract UniswapV2AgnosticGraduationTests is ProtocolAgnosticGraduationTests, La
         super.setUp();
     }
 
-    function _tokenFeeHandler() internal view override returns (ILivoFeeHandler) {
-        return ILivoFeeHandler(ILivoToken(testToken).feeHandler());
+    /// @dev V2 tokens have no fee handler
+    function _tokenFeeHandler() internal pure override returns (ILivoFeeHandler) {
+        revert("V2 tokens have no fee handler");
+    }
+
+    /// @notice V2 tokens have no creator graduation compensation
+    function test_creatorGetsGraduationCompensation() public override createTestToken {
+        // V2 tokens have no fee handler and no creator compensation — nothing to assert
+    }
+
+    /// @notice V2: full graduation fee goes to treasury (no creator split)
+    function test_teamCollectsGraduationFeeInEthAtGraduation() public override createTestToken {
+        uint256 treasuryBalanceBefore = treasury.balance;
+
+        uint256 ethReserves = launchpad.getTokenState(testToken).ethCollected;
+        uint256 missingForGraduation = _increaseWithFees(GRADUATION_THRESHOLD - ethReserves);
+        uint256 expectedTradingFee = (missingForGraduation * BASE_BUY_FEE_BPS) / 10000;
+
+        _graduateToken();
+
+        uint256 feeCollected = treasury.balance - treasuryBalanceBefore;
+        assertEq(
+            feeCollected,
+            GRADUATION_FEE + expectedTradingFee,
+            "Treasury should receive full graduation fee plus trading fees"
+        );
+    }
+
+    /// @notice V2: full graduation fee goes to treasury (no creator split)
+    function test_treasuryEthBalanceChangeAtGraduationAccountsForGraduationFee() public override createTestToken {
+        vm.deal(buyer, 100 ether);
+
+        uint256 treasuryEthBefore = treasury.balance;
+
+        vm.prank(buyer);
+        launchpad.buyTokensWithExactEth{value: GRADUATION_THRESHOLD - 1 ether}(testToken, 0, DEADLINE);
+        assertFalse(launchpad.getTokenState(testToken).graduated, "Token should not be graduated yet");
+        uint256 expectedTradingFees = ((GRADUATION_THRESHOLD - 1 ether) * BASE_BUY_FEE_BPS) / 10000;
+        assertEq(treasury.balance - treasuryEthBefore, expectedTradingFees, "Treasury should collect expected fees");
+
+        uint256 treasuryBalanceBeforeGraduation = treasury.balance;
+
+        uint256 purchaseValue = 1 ether + MAX_THRESHOLD_EXCESS;
+        vm.prank(buyer);
+        launchpad.buyTokensWithExactEth{value: purchaseValue}(testToken, 0, DEADLINE);
+        assertTrue(launchpad.getTokenState(testToken).graduated, "Token should be graduated");
+
+        uint256 tradingFee = (BASE_BUY_FEE_BPS * purchaseValue) / 10000;
+        uint256 totalTreasuryChange = treasury.balance - treasuryBalanceBeforeGraduation;
+
+        assertEq(
+            totalTreasuryChange,
+            tradingFee + GRADUATION_FEE,
+            "Treasury should collect full graduation fee (plus trading fee)"
+        );
     }
 }
 

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -25,8 +25,7 @@ contract BaseUniswapV2GraduationTests is LaunchpadBaseTestsWithUniv2Graduator {
 
     modifier createTestTokenWithPair() {
         vm.prank(creator);
-        testToken =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+        testToken = factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         uniswapPair = UNISWAP_FACTORY.getPair(testToken, address(WETH));
         _;
     }
@@ -112,8 +111,7 @@ contract UniswapV2GraduationTests is BaseUniswapV2GraduationTests {
     /// @notice Test that it is not possible to create the univ2pair right after token is deployed
     function test_cannotCreateUniV2PairRightAfterTokenDeployment() public {
         vm.prank(creator);
-        testToken =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+        testToken = factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         address existingPair = UNISWAP_FACTORY.getPair(testToken, address(WETH));
         assertTrue(existingPair != address(0), "Pair should already exist from token creation");

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -14,9 +14,6 @@ import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {ILivoBondingCurve} from "src/interfaces/ILivoBondingCurve.sol";
 import {IUniswapV2Router02} from "src/interfaces/IUniswapV2Router02.sol";
 
-import {ILivoToken} from "src/interfaces/ILivoToken.sol";
-import {ILivoFeeHandler} from "src/interfaces/ILivoFeeHandler.sol";
-
 contract BaseUniswapV2GraduationTests is LaunchpadBaseTestsWithUniv2Graduator {
     address public uniswapPair;
 
@@ -468,88 +465,5 @@ contract TestGraduationDosExploits is BaseUniswapV2GraduationTests {
         launchpad.buyTokensWithExactEth{value: maxEth}(testToken, 0, DEADLINE);
 
         assertTrue(launchpad.getTokenState(testToken).graduated, "Token should be graduated");
-    }
-}
-
-// ============================================
-// V2 + FeeSplitter + LivoToken
-// ============================================
-
-contract UniswapV2Graduation_Splitter is BaseUniswapV2GraduationTests {
-    address public splitterAddress;
-    address public shareholder1;
-    address public shareholder2;
-
-    function setUp() public override {
-        super.setUp();
-        shareholder1 = makeAddr("shareholder1");
-        shareholder2 = makeAddr("shareholder2");
-    }
-
-    function _recipients() internal view returns (address[] memory r) {
-        r = new address[](2);
-        r[0] = shareholder1;
-        r[1] = shareholder2;
-    }
-
-    function _sharesBps() internal pure returns (uint256[] memory s) {
-        s = new uint256[](2);
-        s[0] = 7000;
-        s[1] = 3000;
-    }
-
-    modifier createSplitterToken() {
-        vm.prank(creator);
-        (address token, address splitter) = factoryV2.createTokenWithFeeSplit(
-            "TestToken", "TEST", _recipients(), _sharesBps(), _nextValidSalt(address(factoryV2), address(livoToken))
-        );
-        testToken = token;
-        splitterAddress = splitter;
-        uniswapPair = UNISWAP_FACTORY.getPair(testToken, address(WETH));
-        _;
-    }
-
-    /// @notice Graduation succeeds with fee splitter on V2
-    function test_graduation_withFeeSplitter_v2() public createSplitterToken {
-        _graduateToken();
-        assertTrue(launchpad.getTokenState(testToken).graduated, "token should be graduated");
-    }
-
-    /// @notice token.feeHandler() returns the splitter
-    function test_feeHandler_isSplitter_v2() public createSplitterToken {
-        _graduateToken();
-        assertEq(ILivoToken(testToken).feeHandler(), splitterAddress, "feeHandler should be splitter");
-        assertEq(ILivoToken(testToken).feeReceiver(), splitterAddress, "feeReceiver should be splitter");
-    }
-
-    /// @notice Graduation compensation is routed through splitter, shareholders can claim
-    function test_graduationCompensation_claimableByShareholders() public createSplitterToken {
-        _graduateToken();
-
-        address[] memory tokens = new address[](1);
-        tokens[0] = testToken;
-
-        address tokenFeeHandler = ILivoToken(testToken).feeHandler();
-        uint256 s1Claimable = ILivoFeeHandler(tokenFeeHandler).getClaimable(tokens, shareholder1)[0];
-        uint256 s2Claimable = ILivoFeeHandler(tokenFeeHandler).getClaimable(tokens, shareholder2)[0];
-
-        assertGt(s1Claimable + s2Claimable, 0, "shareholders should have claimable graduation compensation");
-
-        uint256 s1Before = shareholder1.balance;
-        uint256 s2Before = shareholder2.balance;
-
-        vm.prank(shareholder1);
-        ILivoFeeHandler(tokenFeeHandler).claim(tokens);
-        vm.prank(shareholder2);
-        ILivoFeeHandler(tokenFeeHandler).claim(tokens);
-
-        uint256 s1Earned = shareholder1.balance - s1Before;
-        uint256 s2Earned = shareholder2.balance - s2Before;
-
-        assertGt(s1Earned, 0, "shareholder1 should receive graduation compensation");
-        assertGt(s2Earned, 0, "shareholder2 should receive graduation compensation");
-
-        // 70/30 split of graduation compensation
-        assertApproxEqAbs(s1Earned * 3000, s2Earned * 7000, 1e12, "fee split should respect 70/30 shares");
     }
 }

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -88,11 +88,7 @@ contract LaunchpadInvariants is Test {
         LivoFeeSplitter feeSplitterImpl = new LivoFeeSplitter();
 
         factoryV2 = new LivoFactoryUniV2(
-            address(launchpad),
-            address(tokenImplementation),
-            address(bondingCurve),
-            address(graduatorV2),
-            address(feeHandler)
+            address(launchpad), address(tokenImplementation), address(bondingCurve), address(graduatorV2)
         );
 
         factoryV4 = new LivoFactoryBase(

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -92,8 +92,7 @@ contract LaunchpadInvariants is Test {
             address(tokenImplementation),
             address(bondingCurve),
             address(graduatorV2),
-            address(feeHandler),
-            address(feeSplitterImpl)
+            address(feeHandler)
         );
 
         factoryV4 = new LivoFactoryBase(

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -8,6 +8,7 @@ import {ConstantProductBondingCurve} from "src/bondingCurves/ConstantProductBond
 import {LivoGraduatorUniswapV2} from "src/graduators/LivoGraduatorUniswapV2.sol";
 import {LivoGraduatorUniswapV4} from "src/graduators/LivoGraduatorUniswapV4.sol";
 import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {LivoSwapHook} from "src/hooks/LivoSwapHook.sol";
 import {DeploymentAddressesMainnet} from "src/config/DeploymentAddresses.sol";
 import {LivoFeeHandler} from "src/feeHandlers/LivoFeeHandler.sol";
@@ -22,7 +23,7 @@ contract LaunchpadInvariants is Test {
     ConstantProductBondingCurve public bondingCurve;
     LivoGraduatorUniswapV2 public graduatorV2;
     LivoGraduatorUniswapV4 public graduatorV4;
-    LivoFactoryBase public factoryV2;
+    LivoFactoryUniV2 public factoryV2;
     LivoFactoryBase public factoryV4;
     LivoFeeHandler public feeHandler;
 
@@ -86,7 +87,7 @@ contract LaunchpadInvariants is Test {
 
         LivoFeeSplitter feeSplitterImpl = new LivoFeeSplitter();
 
-        factoryV2 = new LivoFactoryBase(
+        factoryV2 = new LivoFactoryUniV2(
             address(launchpad),
             address(tokenImplementation),
             address(bondingCurve),

--- a/test/invariants/helper.t.sol
+++ b/test/invariants/helper.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {Clones} from "lib/openzeppelin-contracts/contracts/proxy/Clones.sol";
 import {EnumerableSet} from "lib/openzeppelin-contracts/contracts/utils/structs/EnumerableSet.sol";
 import {TokenState} from "src/types/tokenData.sol";
@@ -33,7 +34,7 @@ contract InvariantsHelperLaunchpad is Test {
 
     LivoLaunchpad public launchpad;
 
-    LivoFactoryBase public factoryV2;
+    LivoFactoryUniV2 public factoryV2;
     LivoFactoryBase public factoryV4;
 
     mapping(address => uint256) public aggregatedEthForBuys;
@@ -62,7 +63,7 @@ contract InvariantsHelperLaunchpad is Test {
     }
 
     /////////////////////////////////////////////////////
-    constructor(LivoLaunchpad _launchpad, LivoFactoryBase _factoryV2, LivoFactoryBase _factoryV4) {
+    constructor(LivoLaunchpad _launchpad, LivoFactoryUniV2 _factoryV2, LivoFactoryBase _factoryV4) {
         launchpad = _launchpad;
         factoryV2 = _factoryV2;
         factoryV4 = _factoryV4;
@@ -112,10 +113,16 @@ contract InvariantsHelperLaunchpad is Test {
     //////////////////////////////////////////////////////////
 
     function createToken(uint256 seed) public passTime(seed) choseActor(seed) {
-        LivoFactoryBase factory = seed % 2 == 0 ? factoryV2 : factoryV4;
-        bytes32 salt = _nextValidSalt(address(factory), address(factory.TOKEN_IMPLEMENTATION()));
-        vm.prank(currentActor);
-        address token = factory.createToken("TestToken", "TEST", currentActor, salt);
+        address token;
+        if (seed % 2 == 0) {
+            bytes32 salt = _nextValidSalt(address(factoryV2), address(factoryV2.TOKEN_IMPLEMENTATION()));
+            vm.prank(currentActor);
+            token = factoryV2.createToken("TestToken", "TEST", currentActor, salt);
+        } else {
+            bytes32 salt = _nextValidSalt(address(factoryV4), address(factoryV4.TOKEN_IMPLEMENTATION()));
+            vm.prank(currentActor);
+            token = factoryV4.createToken("TestToken", "TEST", currentActor, salt);
+        }
         _tokens.add(token);
     }
 

--- a/test/invariants/helper.t.sol
+++ b/test/invariants/helper.t.sol
@@ -117,7 +117,7 @@ contract InvariantsHelperLaunchpad is Test {
         if (seed % 2 == 0) {
             bytes32 salt = _nextValidSalt(address(factoryV2), address(factoryV2.TOKEN_IMPLEMENTATION()));
             vm.prank(currentActor);
-            token = factoryV2.createToken("TestToken", "TEST", currentActor, salt);
+            token = factoryV2.createToken("TestToken", "TEST", salt);
         } else {
             bytes32 salt = _nextValidSalt(address(factoryV4), address(factoryV4.TOKEN_IMPLEMENTATION()));
             vm.prank(currentActor);

--- a/test/launchpad/adminFunctions.t.sol
+++ b/test/launchpad/adminFunctions.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {LaunchpadBaseTestsWithUniv2Graduator} from "test/launchpad/base.t.sol";
+import {LaunchpadBaseTestsWithUniv4Graduator} from "test/launchpad/base.t.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {Ownable} from "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {LivoToken} from "src/tokens/LivoToken.sol";
 
-contract AdminFunctionsTest is LaunchpadBaseTestsWithUniv2Graduator {
+contract AdminFunctionsTest is LaunchpadBaseTestsWithUniv4Graduator {
     address public nonOwner = makeAddr("nonOwner");
     address public newTreasury = makeAddr("newTreasury");
 

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -35,13 +35,9 @@ contract TestLivoFactory is LivoFactoryBase {
 }
 
 contract TestLivoFactoryUniV2 is LivoFactoryUniV2 {
-    constructor(
-        address launchpad,
-        address tokenImplementation,
-        address bondingCurve,
-        address graduator,
-        address feeHandler
-    ) LivoFactoryUniV2(launchpad, tokenImplementation, bondingCurve, graduator, feeHandler) {}
+    constructor(address launchpad, address tokenImplementation, address bondingCurve, address graduator)
+        LivoFactoryUniV2(launchpad, tokenImplementation, bondingCurve, graduator)
+    {}
 }
 
 contract LaunchpadBaseTests is Test {
@@ -160,11 +156,7 @@ contract LaunchpadBaseTests is Test {
         LivoFeeSplitter feeSplitterImpl = new LivoFeeSplitter();
 
         factoryV2 = new TestLivoFactoryUniV2(
-            address(launchpad),
-            address(livoToken),
-            address(bondingCurve),
-            address(graduatorV2),
-            address(feeHandler)
+            address(launchpad), address(livoToken), address(bondingCurve), address(graduatorV2)
         );
 
         factoryV4 = new TestLivoFactory(
@@ -211,9 +203,8 @@ contract LaunchpadBaseTests is Test {
                 );
             }
         } else {
-            testToken = factoryV2.createToken(
-                "TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-            );
+            testToken =
+                factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         }
         _;
     }

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -17,6 +17,7 @@ import {IWETH} from "src/interfaces/IWETH.sol";
 import {LivoSwapHook} from "src/hooks/LivoSwapHook.sol";
 import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
 import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {Clones} from "lib/openzeppelin-contracts/contracts/proxy/Clones.sol";
 import {LivoFactoryTaxToken} from "src/factories/LivoFactoryTaxToken.sol";
 import {LivoFeeHandler} from "src/feeHandlers/LivoFeeHandler.sol";
@@ -33,6 +34,17 @@ contract TestLivoFactory is LivoFactoryBase {
     ) LivoFactoryBase(launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, feeSplitterImplementation) {}
 }
 
+contract TestLivoFactoryUniV2 is LivoFactoryUniV2 {
+    constructor(
+        address launchpad,
+        address tokenImplementation,
+        address bondingCurve,
+        address graduator,
+        address feeHandler,
+        address feeSplitterImplementation
+    ) LivoFactoryUniV2(launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, feeSplitterImplementation) {}
+}
+
 contract LaunchpadBaseTests is Test {
     LivoLaunchpad public launchpad;
 
@@ -45,7 +57,7 @@ contract LaunchpadBaseTests is Test {
 
     ILivoGraduator public graduator;
 
-    TestLivoFactory public factoryV2;
+    TestLivoFactoryUniV2 public factoryV2;
     TestLivoFactory public factoryV4;
     LivoFactoryTaxToken public factoryTax;
     LivoFeeHandler public feeHandler;
@@ -148,7 +160,7 @@ contract LaunchpadBaseTests is Test {
 
         LivoFeeSplitter feeSplitterImpl = new LivoFeeSplitter();
 
-        factoryV2 = new TestLivoFactory(
+        factoryV2 = new TestLivoFactoryUniV2(
             address(launchpad),
             address(livoToken),
             address(bondingCurve),

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -40,9 +40,8 @@ contract TestLivoFactoryUniV2 is LivoFactoryUniV2 {
         address tokenImplementation,
         address bondingCurve,
         address graduator,
-        address feeHandler,
-        address feeSplitterImplementation
-    ) LivoFactoryUniV2(launchpad, tokenImplementation, bondingCurve, graduator, feeHandler, feeSplitterImplementation) {}
+        address feeHandler
+    ) LivoFactoryUniV2(launchpad, tokenImplementation, bondingCurve, graduator, feeHandler) {}
 }
 
 contract LaunchpadBaseTests is Test {
@@ -165,8 +164,7 @@ contract LaunchpadBaseTests is Test {
             address(livoToken),
             address(bondingCurve),
             address(graduatorV2),
-            address(feeHandler),
-            address(feeSplitterImpl)
+            address(feeHandler)
         );
 
         factoryV4 = new TestLivoFactory(

--- a/test/launchpad/buyTokens.t.sol
+++ b/test/launchpad/buyTokens.t.sol
@@ -294,9 +294,7 @@ abstract contract BuyTokensTest is LaunchpadBaseTests {
         // Reset state by creating a new token for the second scenario
         vm.prank(creator);
         address testToken2 = address(graduator) == address(graduatorV2)
-            ? factoryV2.createToken(
-                "Test Token 2", "TT2", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-            )
+            ? factoryV2.createToken("Test Token 2", "TT2", _nextValidSalt(address(factoryV2), address(livoToken)))
             : factoryV4.createToken(
                 "Test Token 2", "TT2", creator, _nextValidSalt(address(factoryV4), address(livoToken))
             );

--- a/test/launchpad/createTokens.t.sol
+++ b/test/launchpad/createTokens.t.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {LaunchpadBaseTestsWithUniv2Graduator, LaunchpadBaseTestsWithUniv4GraduatorTaxableToken} from "./base.t.sol";
+import {
+    LaunchpadBaseTestsWithUniv2Graduator,
+    LaunchpadBaseTestsWithUniv4Graduator,
+    LaunchpadBaseTestsWithUniv4GraduatorTaxableToken
+} from "./base.t.sol";
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {LivoToken} from "src/tokens/LivoToken.sol";
 import {TokenConfig, TokenState} from "src/types/tokenData.sol";
@@ -141,6 +145,32 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidFeeReceiver.selector));
         factoryV2.createToken("TestToken", "TEST", address(0), "0x12");
+    }
+}
+
+contract LivoTokenV4DeploymentTest is LaunchpadBaseTestsWithUniv4Graduator {
+    function test_createToken_v4_happyPath() public {
+        vm.prank(creator);
+        address deployedToken =
+            factoryV4.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV4), address(livoToken)));
+
+        assertTrue(deployedToken != address(0));
+
+        LivoToken token = LivoToken(deployedToken);
+        assertEq(token.name(), "TestToken");
+        assertEq(token.symbol(), "TEST");
+        assertEq(token.totalSupply(), TOTAL_SUPPLY);
+        assertEq(token.balanceOf(address(launchpad)), TOTAL_SUPPLY);
+        assertEq(token.graduator(), address(graduatorV4));
+        assertEq(token.owner(), creator);
+
+        TokenConfig memory config = launchpad.getTokenConfig(deployedToken);
+        assertEq(address(config.bondingCurve), address(bondingCurve));
+        assertApproxEqRel(config.bondingCurve.getGraduationConfig().ethGraduationThreshold, GRADUATION_THRESHOLD, 1e10);
+
+        TokenState memory state = launchpad.getTokenState(deployedToken);
+        assertEq(state.ethCollected, 0);
+        assertEq(state.graduated, false);
     }
 }
 

--- a/test/launchpad/createTokens.t.sol
+++ b/test/launchpad/createTokens.t.sol
@@ -138,6 +138,13 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
 }
 
 contract LivoTokenV4DeploymentTest is LaunchpadBaseTestsWithUniv4Graduator {
+    /// @dev when feeReceiver is zero address, then createToken reverts with InvalidFeeReceiver
+    function test_createToken_v4_revertsOnZeroFeeReceiver() public {
+        vm.prank(creator);
+        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidFeeReceiver.selector));
+        factoryV4.createToken("TestToken", "TEST", address(0), "0x12");
+    }
+
     function test_createToken_v4_happyPath() public {
         vm.prank(creator);
         address deployedToken =

--- a/test/launchpad/createTokens.t.sol
+++ b/test/launchpad/createTokens.t.sol
@@ -7,7 +7,7 @@ import {LivoToken} from "src/tokens/LivoToken.sol";
 import {TokenConfig, TokenState} from "src/types/tokenData.sol";
 import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
 import {Vm} from "forge-std/Vm.sol";
-import {LivoFactoryBase} from "src/factories/LivoFactoryBase.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
 import {LivoFactoryTaxToken} from "src/factories/LivoFactoryTaxToken.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
@@ -29,7 +29,7 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
 
         TokenConfig memory config = launchpad.getTokenConfig(deployedToken);
         assertEq(address(config.bondingCurve), address(bondingCurve));
-        assertEq(token.owner(), creator);
+        assertEq(token.owner(), address(0));
         assertApproxEqRel(config.bondingCurve.getGraduationConfig().ethGraduationThreshold, GRADUATION_THRESHOLD, 1e10);
 
         TokenState memory state = launchpad.getTokenState(deployedToken);

--- a/test/launchpad/createTokens.t.sol
+++ b/test/launchpad/createTokens.t.sol
@@ -20,7 +20,7 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     function testDeployLivoToken_happyPath() public {
         vm.prank(creator);
         address deployedToken =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+            factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(deployedToken != address(0));
 
@@ -62,9 +62,8 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
 
     function testTokenCreatedHasDifferentAddressThanImplementation() public {
         vm.prank(creator);
-        address deployedToken = factoryV2.createToken(
-            "Sanitator", "SANIT", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address deployedToken =
+            factoryV2.createToken("Sanitator", "SANIT", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(deployedToken != address(0));
         assertTrue(deployedToken != address(livoToken));
@@ -73,13 +72,13 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
     function testCannotCreateTokenWithEmptyName() public {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("", "TEST", creator, "0x12");
+        factoryV2.createToken("", "TEST", "0x12");
     }
 
     function testCannotCreateTokenWithEmptySymbol() public {
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("TestToken", "", creator, "0x0");
+        factoryV2.createToken("TestToken", "", "0x0");
     }
 
     function testCannotCreateTokenWithWrongEnding() public {
@@ -87,23 +86,21 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.startPrank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidTokenAddress.selector));
-        factoryV2.createToken("TestToken1", "TEST", creator, bytes32(uint256(correctSalt) + 1));
+        factoryV2.createToken("TestToken1", "TEST", bytes32(uint256(correctSalt) + 1));
 
         // with correct salt it should succeed
-        factoryV2.createToken("TestToken1", "TEST", creator, correctSalt);
+        factoryV2.createToken("TestToken1", "TEST", correctSalt);
         vm.stopPrank();
     }
 
     function testCanCreateTokenWithDuplicateSymbol() public {
         vm.prank(creator);
-        address token1 = factoryV2.createToken(
-            "TestToken1", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token1 =
+            factoryV2.createToken("TestToken1", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         vm.prank(creator);
-        address token2 = factoryV2.createToken(
-            "TestToken2", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token2 =
+            factoryV2.createToken("TestToken2", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(token1 != address(0));
         assertTrue(token2 != address(0));
@@ -117,14 +114,12 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
 
     function testCanCreateTokensWithDifferentSymbols() public {
         vm.prank(creator);
-        address token1 = factoryV2.createToken(
-            "TestToken1", "TEST1", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token1 =
+            factoryV2.createToken("TestToken1", "TEST1", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         vm.prank(creator);
-        address token2 = factoryV2.createToken(
-            "TestToken2", "TEST2", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-        );
+        address token2 =
+            factoryV2.createToken("TestToken2", "TEST2", _nextValidSalt(address(factoryV2), address(livoToken)));
 
         assertTrue(token1 != address(0));
         assertTrue(token2 != address(0));
@@ -138,13 +133,7 @@ contract LivoTokenDeploymentTest is LaunchpadBaseTestsWithUniv2Graduator {
         string memory longSymbol = "TESTTESTTESTTESTTESTTESTTESTESESD";
         vm.prank(creator);
         vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidNameOrSymbol.selector));
-        factoryV2.createToken("TestToken", longSymbol, creator, "0x12");
-    }
-
-    function test_cannotCreateTokenWithZeroFeeReceiver() public {
-        vm.prank(creator);
-        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidFeeReceiver.selector));
-        factoryV2.createToken("TestToken", "TEST", address(0), "0x12");
+        factoryV2.createToken("TestToken", longSymbol, "0x12");
     }
 }
 

--- a/test/launchpad/quoteInverse.t.sol
+++ b/test/launchpad/quoteInverse.t.sol
@@ -126,8 +126,7 @@ contract QuoteInverseTests_Univ2 is QuoteInverseTests, LaunchpadBaseTestsWithUni
 
     modifier createTestToken() override(LaunchpadBaseTests) {
         vm.prank(creator);
-        testToken =
-            factoryV2.createToken("TestToken", "TEST", creator, _nextValidSalt(address(factoryV2), address(livoToken)));
+        testToken = factoryV2.createToken("TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)));
         _;
     }
 }

--- a/test/launchpad/sellTokens.t.sol
+++ b/test/launchpad/sellTokens.t.sol
@@ -351,9 +351,7 @@ abstract contract SellTokensTest is LaunchpadBaseTests {
         // Reset state by creating a new token and setting up the same initial conditions
         vm.prank(creator);
         address testToken2 = address(graduator) == address(graduatorV2)
-            ? factoryV2.createToken(
-                "Test Token 2", "TT2", creator, _nextValidSalt(address(factoryV2), address(livoToken))
-            )
+            ? factoryV2.createToken("Test Token 2", "TT2", _nextValidSalt(address(factoryV2), address(livoToken)))
             : factoryV4.createToken(
                 "Test Token 2", "TT2", creator, _nextValidSalt(address(factoryV4), address(livoToken))
             );

--- a/test/launchpad/tokenOwnershipTransfer.t.sol
+++ b/test/launchpad/tokenOwnershipTransfer.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {LaunchpadBaseTestsWithUniv2Graduator} from "test/launchpad/base.t.sol";
+import {LaunchpadBaseTestsWithUniv4Graduator} from "test/launchpad/base.t.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {LivoToken} from "src/tokens/LivoToken.sol";
 
-contract TokenOwnershipTransferTests is LaunchpadBaseTestsWithUniv2Graduator {
+contract TokenOwnershipTransferTests is LaunchpadBaseTestsWithUniv4Graduator {
     modifier proposedOwner(address currentOwner, address nextOwner) {
         vm.prank(currentOwner);
         ILivoToken(testToken).proposeNewOwner(nextOwner);


### PR DESCRIPTION
- **tests: price impact simulations**
- **feat: separate factoryuniv2**
- **test: univ2tokens have no owner, so this tests make only sense for v4**
- **test: declarations of factoryv2 as its own class**
- **test: v2 token.owner == address(0) , not creator anymore**
- **tests: univ2 factory have no fees and no fee splitter anymore, so these tests are not needed**
- **test: dedicated tests for factoryv4 with different assertions than univ2 factory**
- **feat: removed feesplitter implementation from the factoryuniv2 contract, as there are no fee splits there**
- **feat: univ2 graduator full graduation fee to treasury. Removed fee handler and fee receiver from factoryuniv2**
- **test: updated signatures**
- **tests: updated test signatures and removed tests that didnt' allow feeReceiver==address(0)**
- **chore: forge fmt**
- **test: added test to assert feeReceiver!=address(0) for v4 tokens**
