### PR TITLE
feat/create univ2 pair address at graduation and precompute at creation

### DIFF
--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23` |
 | LivoFeeHandler                               | `0xc18030d76573784fff4E6365309E1acD967506ff` |
 | LivoSwapHook                                 | `0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc` |
-| LivoGraduatorUniswapV2                       | `0x1760618972F2F9cad4a78ee464ca917737AAE2DA` |
+| LivoGraduatorUniswapV2                       | `0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC` |
 | LivoGraduatorUniswapV4                       | `0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944` |
 | LivoFeeSplitter (impl)                       | `0x80d97b49169067f339934C39F3ae76C50ED046a6` |
 | LivoQuoter                                   | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
@@ -18,10 +18,10 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x4AdcBa218E3F6615C642B4eDe6c22A7229330e33` |
 | LivoTokenSniperProtected (impl)              | `0x5AD0311eD744fe0a43C244E44E2075758a924F36` |
 | LivoTaxableTokenUniV4SniperProtected (impl)  | `0xf8c0796B6500309f9b08163e33F16F2448254A29` |
-| LivoFactoryUniV2                             | `0xEd16647144C099E3Ef5B60a6714c5C42E15f61Bb` |
+| LivoFactoryUniV2                             | `0x474D8aF8f3B7003BE53ad1B9266cea074060B7aF` |
 | LivoFactoryUniV4                             | `0xD2c2af16c76f2640fDF1208B6fEA107059079ffc` |
 | LivoFactoryTaxToken                          | `0x57aA990063b49cABf3EE9FeB49dca8DADc9511cD` |
-| LivoFactoryUniV2SniperProtected              | `0x95e2C672aeeA71aE7a1b2058CF9de63B7261C7ca` |
+| LivoFactoryUniV2SniperProtected              | `0xef4EE2b87A7EAb545395E3dD4bF5931f51d39A34` |
 | LivoFactoryUniV4SniperProtected              | `0x8f8142E3438bF05e50F8322ce159C507Cc21A577` |
 | LivoFactoryTaxTokenSniperProtected           | `0x1F630Ae795353Dbee4E8a48ce242Fb18479A9333` |
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5` |
 | LivoFeeHandler                               | `0xC8e37Ff6bE0f3Ad39cF7481f8D5Ec89c96Bc48EF` |
 | LivoSwapHook                                 | `0x0591a87D3a56797812C4DA164C1B005c545400Cc` |
-| LivoGraduatorUniswapV2                       | `0x9ac078c4E22917db450624632eA1997aD2ED4C73` |
+| LivoGraduatorUniswapV2                       | `0x67C95f98fa373781bc09efBff3c6a6E3614FE6e6` |
 | LivoGraduatorUniswapV4                       | `0x85fE2051413a4b80b904f05841d1142FeF7f789c` |
 | LivoFeeSplitter (impl)                       | `0xDEAA2606f3F6Ff3B4277a30B7dCD382F9BA4bdB7` |
 | LivoQuoter                                   | `0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438` |
@@ -18,10 +18,10 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x3102B1b7b4F7e0CC32e8e50F303dd0452e1f9323` |
 | LivoTokenSniperProtected (impl)              | `0xBaFe48EeF04D06b4217d16Afea8ab13356ADC316` |
 | LivoTaxableTokenUniV4SniperProtected (impl)  | `0x90191ADfC2DfB4E49897C55fD797aa97f5710cD9` |
-| LivoFactoryUniV2                             | `0x933b7b99974bcf598c1E9abe8e513F5E08eEf11E` |
+| LivoFactoryUniV2                             | `0x8a6f7A98Bb71d21D50cB799F7574A528b41Dc52b` |
 | LivoFactoryUniV4                             | `0x9039E9d741cF71C522ec3407dA34FA8eccE95531` |
 | LivoFactoryTaxToken                          | `0x09af239e3FfaD62482504868c335d9e0F2eCD3be` |
-| LivoFactoryUniV2SniperProtected              | `0x30Cb195a8b7E69636Dd5b0F99939deB6FFD5F1e1` |
+| LivoFactoryUniV2SniperProtected              | `0x0b428B51B81AD8BE825B55A8094eDbf7a4A55988` |
 | LivoFactoryUniV4SniperProtected              | `0xFb81a889D90A8aB35D09fC4467174B0647B65563` |
 | LivoFactoryTaxTokenSniperProtected           | `0xB975497b333B64352aAc32c1431C433ea9607719` |
 

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -177,7 +177,7 @@ When the buy pushes `ethCollected` over the threshold, the same call continues i
 3. **`ERC20.Transfer`** (launchpad → graduator, `value = tokensForGraduation`): launchpad forwards graduation-reserved tokens.
 4. **`LivoGraduator.CreatorGraduationFeeCollected`** (`token, amount = 1.25e17` for V2).
 5. **`LivoFeeHandler.CreatorFeesDeposited`** (`token, account=creator, amount`) — creator share routed through `token.accrueFees()` → `feeHandler.depositFees()`. *For fee-split tokens this is instead `LivoFeeSplitter.FeesAccrued` — see §6 note below.*
-6. **`LivoGraduator.TreasuryGraduationFeeCollected`** (`token, amount`).
+6. **`LivoGraduator.TreasuryGraduationFeeCollected`** (`token, amount = 1.23e17` for V2). The treasury share is `GRADUATION_ETH_FEE - CREATOR_GRADUATION_COMPENSATION - TRIGGERER_GRADUATION_COMPENSATION = 0.123 ether`. The graduator also performs a best-effort, non-reverting push of `TRIGGERER_GRADUATION_COMPENSATION = 0.002 ether` to `tx.origin` (the original buyer's transaction origin) right before this step — no Livo event is emitted for that transfer; if it fails the 0.002 stays in the graduator and is later swept to treasury via `SweepedRemainingEth` (see note below).
 7. **`UniswapV2Factory.PairCreated`** (external) — **conditional**: only fires when no outside actor pre-created the pair. The pair is no longer deployed at token creation (see §1a); the graduator deploys it lazily here via `factory.createPair(token, WETH)` only when `factory.getPair(token, WETH) == address(0)`. The deployed address always equals `LivoToken.pair()` (precomputed CREATE2).
 8. **`ILivoToken.Graduated`** (no args) — from `LivoToken.markGraduated()`.
 9. **`ERC20.Approval`** (external, from graduator to `UniswapV2Router02`, `value = tokensForGraduation`) — ERC20 approval.
@@ -192,7 +192,7 @@ When the buy pushes `ethCollected` over the threshold, the same call continues i
 18. **`LivoGraduator.TokenGraduated`** (`token, tokenAmount, ethAmount, liquidity`).
 19. **`LivoLaunchpad.TokenGraduated`** (`token, ethCollected, tokensForGraduation`) — note: distinct event from `LivoGraduator.TokenGraduated`, same name but different signature.
 
-**Conditional**: if after `addLiquidityETH` the graduator holds leftover ETH, it emits **`LivoGraduator.SweepedRemainingEth`** (`token, amount`) before `TokenGraduated`. This is rare on the happy path (excess was already capped by `MAX_EXCESS`) but possible when the V2 pool is pre-seeded with reserves.
+**Conditional**: if after `addLiquidityETH` the graduator holds leftover ETH, it emits **`LivoGraduator.SweepedRemainingEth`** (`token, amount`) before `TokenGraduated`. Reasons this can fire: (a) the V2 pool was pre-seeded with reserves so `addLiquidityETH` returned dust; (b) `tx.origin` could not receive the 0.002 ether triggerer compensation (see step 6), so that amount fell through to the sweep; or (c) any `addLiquidityETH` rounding leftover. On a clean happy path with an EOA `tx.origin` and no pre-seeded reserves, the sweep does not fire.
 
 Test: `test/graduators/graduation.t.sol::UniswapV2AgnosticGraduationTests::test_graduatedBooleanTurnsTrueInLaunchpad`.
 

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -51,11 +51,10 @@ Same dispatch shape as every other factory: `feeReceivers.length == 1` → direc
 ### 1a. Single fee receiver, no deployer buy (`msg.value == 0`, `feeReceivers.length == 1`)
 
 1. **`LivoFactory.TokenCreated`** (`token, name, symbol, tokenOwner=address(0), launchpad, graduator, feeHandler=LivoFeeHandler, feeReceiver=feeReceivers[0].account`) — emitted by the factory *before* `initialize()` so indexers see the entity first.
-2. **`UniswapV2Factory.PairCreated`** (external) — pair for `<token, WETH>` created by graduator's `initialize()`.
-3. **`LivoGraduator.PairInitialized`** (`token, pair`) — graduator records the pair.
-4. **`ERC20.Transfer`** (from `0x0` to `LivoLaunchpad`, `value = 1e27`) — initial `1_000_000_000 * 1e18` mint to the launchpad.
-5. **`Initializable.Initialized`** (OpenZeppelin, `version=1`) — token clone marked initialized.
-6. **`LivoLaunchpad.TokenLaunched`** (`token, graduationThreshold=3.75e18, maxExcessOverThreshold=5e16`) — launchpad registers the token.
+2. **`LivoGraduator.PairInitialized`** (`token, pair`) — graduator records the **precomputed** CREATE2 pair address. The pair contract itself is **NOT** deployed at this point; it is deployed lazily at graduation (see §6). Off-chain consumers should read `LivoToken.pair()` to obtain the pair address pre-graduation rather than `UniswapV2Factory.getPair(token, WETH)` (which returns `address(0)` until the pair is deployed).
+3. **`ERC20.Transfer`** (from `0x0` to `LivoLaunchpad`, `value = 1e27`) — initial `1_000_000_000 * 1e18` mint to the launchpad.
+4. **`Initializable.Initialized`** (OpenZeppelin, `version=1`) — token clone marked initialized.
+5. **`LivoLaunchpad.TokenLaunched`** (`token, graduationThreshold=3.75e18, maxExcessOverThreshold=5e16`) — launchpad registers the token.
 
 Test: `test/launchpad/createTokens.t.sol::testDeployLivoToken_happyPath`.
 
@@ -63,9 +62,9 @@ Test: `test/launchpad/createTokens.t.sol::testDeployLivoToken_happyPath`.
 
 All of 1a (with `feeHandler` = `feeReceiver` = the splitter clone in the `TokenCreated` event), then append the splitter tail from §4:
 
-7. **`LivoFactory.FeeSplitterCreated`** (`token, feeSplitter, recipients, sharesBps`) — emitted *before* the splitter's `initialize()`.
-8. **`LivoFeeSplitter.SharesUpdated`** (`recipients, sharesBps`).
-9. **`Initializable.Initialized`** (splitter clone, `version=1`).
+6. **`LivoFactory.FeeSplitterCreated`** (`token, feeSplitter, recipients, sharesBps`) — emitted *before* the splitter's `initialize()`.
+7. **`LivoFeeSplitter.SharesUpdated`** (`recipients, sharesBps`).
+8. **`Initializable.Initialized`** (splitter clone, `version=1`).
 
 ### 1c. With deployer buy (`msg.value > 0`)
 
@@ -179,18 +178,19 @@ When the buy pushes `ethCollected` over the threshold, the same call continues i
 4. **`LivoGraduator.CreatorGraduationFeeCollected`** (`token, amount = 1.25e17` for V2).
 5. **`LivoFeeHandler.CreatorFeesDeposited`** (`token, account=creator, amount`) — creator share routed through `token.accrueFees()` → `feeHandler.depositFees()`. *For fee-split tokens this is instead `LivoFeeSplitter.FeesAccrued` — see §6 note below.*
 6. **`LivoGraduator.TreasuryGraduationFeeCollected`** (`token, amount`).
-7. **`ILivoToken.Graduated`** (no args) — from `LivoToken.markGraduated()`.
-8. **`ERC20.Approval`** (external, from graduator to `UniswapV2Router02`, `value = tokensForGraduation`) — ERC20 approval.
-9. **`UniswapV2Pair.Sync`** (external, `reserve0=0, reserve1=0`).
-10. **`ERC20.Transfer`** (external, graduator → pair, `value = tokensForGraduation`) — token side of the add-liquidity.
-11. **`WETH9.Deposit`** (external, `dst=UniswapV2Router02, wad=ethForLiquidity`).
-12. **`WETH9.Transfer`** (external, router → pair, `value = ethForLiquidity`).
-13. **`UniswapV2Pair.Transfer`** (external, LP-token mint `from=0x0, to=0x0, value=1000`) — MINIMUM_LIQUIDITY locked to the zero address.
-14. **`UniswapV2Pair.Transfer`** (external, LP-token mint `from=0x0, to=DEAD_ADDRESS=0x…dEaD, value=<LP minted>`) — LP tokens permanently burned per Livo design.
-15. **`UniswapV2Pair.Sync`** (external, final reserves).
-16. **`UniswapV2Pair.Mint`** (external, `sender=router, amount0, amount1`).
-17. **`LivoGraduator.TokenGraduated`** (`token, tokenAmount, ethAmount, liquidity`).
-18. **`LivoLaunchpad.TokenGraduated`** (`token, ethCollected, tokensForGraduation`) — note: distinct event from `LivoGraduator.TokenGraduated`, same name but different signature.
+7. **`UniswapV2Factory.PairCreated`** (external) — **conditional**: only fires when no outside actor pre-created the pair. The pair is no longer deployed at token creation (see §1a); the graduator deploys it lazily here via `factory.createPair(token, WETH)` only when `factory.getPair(token, WETH) == address(0)`. The deployed address always equals `LivoToken.pair()` (precomputed CREATE2).
+8. **`ILivoToken.Graduated`** (no args) — from `LivoToken.markGraduated()`.
+9. **`ERC20.Approval`** (external, from graduator to `UniswapV2Router02`, `value = tokensForGraduation`) — ERC20 approval.
+10. **`UniswapV2Pair.Sync`** (external, `reserve0=0, reserve1=0`).
+11. **`ERC20.Transfer`** (external, graduator → pair, `value = tokensForGraduation`) — token side of the add-liquidity.
+12. **`WETH9.Deposit`** (external, `dst=UniswapV2Router02, wad=ethForLiquidity`).
+13. **`WETH9.Transfer`** (external, router → pair, `value = ethForLiquidity`).
+14. **`UniswapV2Pair.Transfer`** (external, LP-token mint `from=0x0, to=0x0, value=1000`) — MINIMUM_LIQUIDITY locked to the zero address.
+15. **`UniswapV2Pair.Transfer`** (external, LP-token mint `from=0x0, to=DEAD_ADDRESS=0x…dEaD, value=<LP minted>`) — LP tokens permanently burned per Livo design.
+16. **`UniswapV2Pair.Sync`** (external, final reserves).
+17. **`UniswapV2Pair.Mint`** (external, `sender=router, amount0, amount1`).
+18. **`LivoGraduator.TokenGraduated`** (`token, tokenAmount, ethAmount, liquidity`).
+19. **`LivoLaunchpad.TokenGraduated`** (`token, ethCollected, tokensForGraduation`) — note: distinct event from `LivoGraduator.TokenGraduated`, same name but different signature.
 
 **Conditional**: if after `addLiquidityETH` the graduator holds leftover ETH, it emits **`LivoGraduator.SweepedRemainingEth`** (`token, amount`) before `TokenGraduated`. This is rare on the happy path (excess was already capped by `MAX_EXCESS`) but possible when the V2 pool is pre-seeded with reserves.
 
@@ -354,15 +354,14 @@ Test: `test/factories/LivoFactoryUniV4SniperProtected.t.sol::test_createToken_ha
 
 ### 14.2. `LivoFactoryUniV2SniperProtected.createToken` (V2 graduator, `LivoTokenSniperProtected`)
 
-Signature identical to §14.1. Uses the V2 graduator (ownership renounced at creation, `tokenOwner = address(0)` in `TokenCreated`). Event sequence mirrors §1a plus `SniperProtectionInitialized`:
+Signature identical to §14.1. Uses the V2 graduator (ownership renounced at creation, `tokenOwner = address(0)` in `TokenCreated`). Event sequence mirrors §1a plus `SniperProtectionInitialized`. As in §1a, the UniV2 pair is **not** deployed at this point — only its CREATE2 address is reserved; deployment happens at graduation (see §6):
 
 1. **`LivoFactory.TokenCreated`** (`tokenOwner = address(0)`).
-2. **`UniswapV2Factory.PairCreated`** (external).
-3. **`LivoGraduator.PairInitialized`**.
-4. **`ERC20.Transfer`** (mint `1e27` to launchpad).
-5. **`SniperProtection.SniperProtectionInitialized`** — NEW.
-6. **`Initializable.Initialized`** (`version=1`).
-7. **`LivoLaunchpad.TokenLaunched`**.
+2. **`LivoGraduator.PairInitialized`** — precomputed CREATE2 address; pair contract not yet deployed.
+3. **`ERC20.Transfer`** (mint `1e27` to launchpad).
+4. **`SniperProtection.SniperProtectionInitialized`** — NEW.
+5. **`Initializable.Initialized`** (`version=1`).
+6. **`LivoLaunchpad.TokenLaunched`**.
 
 Test: `test/factories/LivoFactoryUniV2SniperProtected.t.sol::test_createToken_happyPath_ownerIsZero`.
 

--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -172,7 +172,10 @@ contract Deployments is Script {
         console.log("| LivoSwapHook | ", hookAddress);
 
         // 8. Deploy LivoGraduatorUniswapV2
-        LivoGraduatorUniswapV2 graduatorV2 = new LivoGraduatorUniswapV2(univ2Router, address(launchpad));
+        // Stock UniswapV2 pair init code hash (mainnet & Sepolia use the same UniV2 deployment)
+        bytes32 univ2PairInitCodeHash = 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f;
+        LivoGraduatorUniswapV2 graduatorV2 =
+            new LivoGraduatorUniswapV2(univ2Router, address(launchpad), univ2PairInitCodeHash);
         console.log("| LivoGraduatorUniswapV2 | ", address(graduatorV2));
 
         // 7. Deploy LivoGraduatorUniswapV4

--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -50,7 +50,13 @@ contract Deployments is Script {
     function _getNetworkAddresses()
         internal
         view
-        returns (address univ2Router, address univ4PoolManager, address univ4PositionManager, address permit2)
+        returns (
+            address univ2Router,
+            address univ4PoolManager,
+            address univ4PositionManager,
+            address permit2,
+            bytes32 univ2PairInitCodeHash
+        )
     {
         if (block.chainid == 1) {
             // Mainnet
@@ -58,12 +64,14 @@ contract Deployments is Script {
             univ4PoolManager = DeploymentAddressesMainnet.UNIV4_POOL_MANAGER;
             univ4PositionManager = DeploymentAddressesMainnet.UNIV4_POSITION_MANAGER;
             permit2 = DeploymentAddressesMainnet.PERMIT2;
+            univ2PairInitCodeHash = DeploymentAddressesMainnet.UNIV2_PAIR_INIT_CODE_HASH;
         } else if (block.chainid == 11155111) {
             // Sepolia
             univ2Router = DeploymentAddressesSepolia.UNIV2_ROUTER;
             univ4PoolManager = DeploymentAddressesSepolia.UNIV4_POOL_MANAGER;
             univ4PositionManager = DeploymentAddressesSepolia.UNIV4_POSITION_MANAGER;
             permit2 = DeploymentAddressesSepolia.PERMIT2;
+            univ2PairInitCodeHash = DeploymentAddressesSepolia.UNIV2_PAIR_INIT_CODE_HASH;
         } else {
             revert("Unsupported chain");
         }
@@ -123,8 +131,13 @@ contract Deployments is Script {
     function run() public {
         require(TREASURY != address(0), "TREASURY address not set");
 
-        (address univ2Router, address univ4PoolManager, address univ4PositionManager, address permit2) =
-            _getNetworkAddresses();
+        (
+            address univ2Router,
+            address univ4PoolManager,
+            address univ4PositionManager,
+            address permit2,
+            bytes32 univ2PairInitCodeHash
+        ) = _getNetworkAddresses();
 
         console.log("=== Livo Protocol Deployment ===");
         console.log("Chain ID:", block.chainid);
@@ -172,8 +185,6 @@ contract Deployments is Script {
         console.log("| LivoSwapHook | ", hookAddress);
 
         // 8. Deploy LivoGraduatorUniswapV2
-        // Stock UniswapV2 pair init code hash (mainnet & Sepolia use the same UniV2 deployment)
-        bytes32 univ2PairInitCodeHash = 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f;
         LivoGraduatorUniswapV2 graduatorV2 =
             new LivoGraduatorUniswapV2(univ2Router, address(launchpad), univ2PairInitCodeHash);
         console.log("| LivoGraduatorUniswapV2 | ", address(graduatorV2));

--- a/script/DeploymentsGraduatorAndFactoriesUniV2.sol
+++ b/script/DeploymentsGraduatorAndFactoriesUniV2.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
+
+import {LivoGraduatorUniswapV2} from "src/graduators/LivoGraduatorUniswapV2.sol";
+import {LivoFactoryUniV2} from "src/factories/LivoFactoryUniV2.sol";
+import {LivoFactoryUniV2SniperProtected} from "src/factories/LivoFactoryUniV2SniperProtected.sol";
+
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @title Livo V2 Graduator + V2 Factories Re-Deployment
+/// @notice Deploys a fresh `LivoGraduatorUniswapV2` and the two V2 factories
+///         (`LivoFactoryUniV2`, `LivoFactoryUniV2SniperProtected`) wired against the new graduator.
+///         Reuses the live core (launchpad, bonding curve, fee handler, fee splitter impl) and the
+///         existing token implementations from `deployments.{mainnet,sepolia}.sol`.
+///         Whitelists both new factories on the launchpad in the same broadcast.
+/// @dev Run with:
+///      forge script DeploymentsGraduatorAndFactoriesUniV2 --rpc-url <mainnet|sepolia> --broadcast --verify --account livo.dev --slow
+contract DeploymentsGraduatorAndFactoriesUniV2 is Script {
+    struct Deps {
+        address launchpad;
+        address bondingCurve;
+        address feeHandler;
+        address feeSplitterImpl;
+        address tokenImpl;
+        address tokenSniperImpl;
+        address univ2Router;
+        bytes32 univ2PairInitCodeHash;
+    }
+
+    /// @notice Resolves the deps needed to deploy the V2 graduator + V2 factories on the active chain.
+    /// @dev Core/token-impl addresses come from `deployments.{mainnet,sepolia}.sol`.
+    ///      UniV2 router + pair init-code hash come from `DeploymentAddresses.sol`.
+    function _getDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                bondingCurve: DeploymentsMainnet.BONDING_CURVE,
+                feeHandler: DeploymentsMainnet.FEE_HANDLER,
+                feeSplitterImpl: DeploymentsMainnet.FEE_SPLITTER_IMPL,
+                tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL,
+                univ2Router: DeploymentAddressesMainnet.UNIV2_ROUTER,
+                univ2PairInitCodeHash: DeploymentAddressesMainnet.UNIV2_PAIR_INIT_CODE_HASH
+            });
+        } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                bondingCurve: DeploymentsSepolia.BONDING_CURVE,
+                feeHandler: DeploymentsSepolia.FEE_HANDLER,
+                feeSplitterImpl: DeploymentsSepolia.FEE_SPLITTER_IMPL,
+                tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL,
+                univ2Router: DeploymentAddressesSepolia.UNIV2_ROUTER,
+                univ2PairInitCodeHash: DeploymentAddressesSepolia.UNIV2_PAIR_INIT_CODE_HASH
+            });
+        } else {
+            revert("Unsupported chain");
+        }
+    }
+
+    function run() public {
+        Deps memory d = _getDeps();
+
+        console.log("=== Livo V2 Graduator + V2 Factories Deployment ===");
+        console.log("Chain ID:", block.chainid);
+        console.log("Deployer:", msg.sender);
+        console.log("Launchpad:", d.launchpad);
+        console.log("UniV2 Router:", d.univ2Router);
+        console.log("");
+
+        vm.startBroadcast();
+
+        console.log("| Contract Name | Address |");
+        console.log("| ---- | --- |");
+
+        // 1. Deploy fresh V2 graduator (constructor takes the centralized pair init-code hash).
+        LivoGraduatorUniswapV2 graduatorV2 =
+            new LivoGraduatorUniswapV2(d.univ2Router, d.launchpad, d.univ2PairInitCodeHash);
+        console.log("| LivoGraduatorUniswapV2 | ", address(graduatorV2));
+
+        // 2. Deploy V2 factory wired to the *just-deployed* graduator (not the manifest's stale one).
+        LivoFactoryUniV2 factoryV2 = new LivoFactoryUniV2(
+            d.launchpad, d.tokenImpl, d.bondingCurve, address(graduatorV2), d.feeHandler, d.feeSplitterImpl
+        );
+        console.log("| LivoFactoryUniV2 | ", address(factoryV2));
+
+        // 3. Deploy sniper-protected V2 factory wired to the same new graduator.
+        LivoFactoryUniV2SniperProtected factoryV2Sniper = new LivoFactoryUniV2SniperProtected(
+            d.launchpad, d.tokenSniperImpl, d.bondingCurve, address(graduatorV2), d.feeHandler, d.feeSplitterImpl
+        );
+        console.log("| LivoFactoryUniV2SniperProtected | ", address(factoryV2Sniper));
+
+        // whitelisting has to be done with livo.admin account instead
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Deployment Complete ===");
+        console.log("Next steps:");
+        console.log("1. Update GRADUATOR_UNIV2 / FACTORY_UNIV2 / FACTORY_UNIV2_SNIPER_PROTECTED in");
+        console.log("   src/config/deployments.{mainnet,sepolia}.sol with the addresses above.");
+        console.log("2. Run `just export-deployments` to refresh the .md manifests and commit.");
+        console.log("3. Whitelist factories in launchpad");
+    }
+}

--- a/src/config/DeploymentAddresses.sol
+++ b/src/config/DeploymentAddresses.sol
@@ -37,6 +37,12 @@ library DeploymentAddressesMainnet {
     /// @dev Creates and manages V2 pair contracts
     address public constant UNIV2_FACTORY = 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
 
+    /// @notice keccak256 of the UniswapV2Pair contract creation code used by UNIV2_FACTORY
+    /// @dev Required by `LivoGraduatorUniswapV2` to predict the CREATE2 pair address without
+    ///      deploying the pair upfront. Canonical stock UniswapV2 value.
+    bytes32 public constant UNIV2_PAIR_INIT_CODE_HASH =
+        0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f;
+
     /// @notice Dead address used for burning LP tokens
     /// @dev Standard burn address that works on all chains
     address public constant DEAD_ADDRESS = 0x000000000000000000000000000000000000dEaD;
@@ -71,6 +77,13 @@ library DeploymentAddressesSepolia {
 
     /// @notice Uniswap V2 Factory contract
     address public constant UNIV2_FACTORY = 0x7E0987E5b3a30e3f2828572Bb659A548460a3003;
+
+    /// @notice keccak256 of the UniswapV2Pair contract creation code used by UNIV2_FACTORY
+    /// @dev Required by `LivoGraduatorUniswapV2` to predict the CREATE2 pair address without
+    ///      deploying the pair upfront. Sepolia's UniV2 deployment uses the same canonical
+    ///      stock pair bytecode as mainnet, so the hash matches.
+    bytes32 public constant UNIV2_PAIR_INIT_CODE_HASH =
+        0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f;
 
     /// @notice Dead address used for burning LP tokens
     /// @dev Standard burn address that works on all chains

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -13,7 +13,7 @@ library DeploymentsMainnet {
     // --- Core ---
     address internal constant LAUNCHPAD = 0xd9f8bbe437a3423b725c6616C1B543775ecf1110;
     address internal constant BONDING_CURVE = 0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23;
-    address internal constant GRADUATOR_UNIV2 = 0x1760618972F2F9cad4a78ee464ca917737AAE2DA;
+    address internal constant GRADUATOR_UNIV2 = 0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC;
     address internal constant GRADUATOR_UNIV4 = 0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944;
     address internal constant FEE_HANDLER = 0xc18030d76573784fff4E6365309E1acD967506ff;
     address internal constant FEE_SPLITTER_IMPL = 0x80d97b49169067f339934C39F3ae76C50ED046a6;
@@ -30,12 +30,12 @@ library DeploymentsMainnet {
     address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0xf8c0796B6500309f9b08163e33F16F2448254A29;
 
     // --- Factories ---
-    address internal constant FACTORY_UNIV2 = 0xEd16647144C099E3Ef5B60a6714c5C42E15f61Bb;
+    address internal constant FACTORY_UNIV2 = 0x474D8aF8f3B7003BE53ad1B9266cea074060B7aF;
     address internal constant FACTORY_UNIV4 = 0xD2c2af16c76f2640fDF1208B6fEA107059079ffc;
     address internal constant FACTORY_TAX_TOKEN = 0x57aA990063b49cABf3EE9FeB49dca8DADc9511cD;
 
     /// @notice Sniper-protected factories
-    address internal constant FACTORY_UNIV2_SNIPER_PROTECTED = 0x95e2C672aeeA71aE7a1b2058CF9de63B7261C7ca;
+    address internal constant FACTORY_UNIV2_SNIPER_PROTECTED = 0xef4EE2b87A7EAb545395E3dD4bF5931f51d39A34;
     address internal constant FACTORY_UNIV4_SNIPER_PROTECTED = 0x8f8142E3438bF05e50F8322ce159C507Cc21A577;
     address internal constant FACTORY_TAX_TOKEN_SNIPER_PROTECTED = 0x1F630Ae795353Dbee4E8a48ce242Fb18479A9333;
 

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -14,7 +14,7 @@ library DeploymentsSepolia {
     // --- Core ---
     address internal constant LAUNCHPAD = 0xd9f8bbe437a3423b725c6616C1B543775ecf1110;
     address internal constant BONDING_CURVE = 0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5;
-    address internal constant GRADUATOR_UNIV2 = 0x9ac078c4E22917db450624632eA1997aD2ED4C73;
+    address internal constant GRADUATOR_UNIV2 = 0x67C95f98fa373781bc09efBff3c6a6E3614FE6e6;
     address internal constant GRADUATOR_UNIV4 = 0x85fE2051413a4b80b904f05841d1142FeF7f789c;
     address internal constant FEE_HANDLER = 0xC8e37Ff6bE0f3Ad39cF7481f8D5Ec89c96Bc48EF;
     address internal constant FEE_SPLITTER_IMPL = 0xDEAA2606f3F6Ff3B4277a30B7dCD382F9BA4bdB7;
@@ -31,11 +31,11 @@ library DeploymentsSepolia {
     address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x90191ADfC2DfB4E49897C55fD797aa97f5710cD9;
 
     // --- Factories ---
-    address internal constant FACTORY_UNIV2 = 0x933b7b99974bcf598c1E9abe8e513F5E08eEf11E;
+    address internal constant FACTORY_UNIV2 = 0x8a6f7A98Bb71d21D50cB799F7574A528b41Dc52b;
     address internal constant FACTORY_UNIV4 = 0x9039E9d741cF71C522ec3407dA34FA8eccE95531;
     address internal constant FACTORY_TAX_TOKEN = 0x09af239e3FfaD62482504868c335d9e0F2eCD3be;
 
-    address internal constant FACTORY_UNIV2_SNIPER_PROTECTED = 0x30Cb195a8b7E69636Dd5b0F99939deB6FFD5F1e1;
+    address internal constant FACTORY_UNIV2_SNIPER_PROTECTED = 0x0b428B51B81AD8BE825B55A8094eDbf7a4A55988;
     address internal constant FACTORY_UNIV4_SNIPER_PROTECTED = 0xFb81a889D90A8aB35D09fC4467174B0647B65563;
     address internal constant FACTORY_TAX_TOKEN_SNIPER_PROTECTED = 0xB975497b333B64352aAc32c1431C433ea9607719;
 

--- a/src/graduators/LivoGraduatorUniswapV2.sol
+++ b/src/graduators/LivoGraduatorUniswapV2.sol
@@ -33,6 +33,11 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
 
     /// @notice Wrapped ETH address
     address internal immutable WETH;
+
+    /// @notice Init code hash of the Uniswap V2 pair contract used by the configured factory.
+    ///         Required to predict the CREATE2 pair address without deploying the pair upfront.
+    /// @dev Stock UniswapV2 mainnet/Sepolia value is `0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f`.
+    bytes32 internal immutable PAIR_INIT_CODE_HASH;
     //////////////////////// EVENTS ////////////////////////
 
     event SweepedRemainingEth(address graduatedToken, uint256 amount);
@@ -47,20 +52,44 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
     /// @notice Initializes the Uniswap V2 graduator
     /// @param _uniswapRouter Address of the Uniswap V2 router
     /// @param _launchpad Address of the LivoLaunchpad contract
-    constructor(address _uniswapRouter, address _launchpad) {
+    /// @param _pairInitCodeHash keccak256 of the pair contract creation code used by the configured factory
+    constructor(address _uniswapRouter, address _launchpad, bytes32 _pairInitCodeHash) {
         LIVO_LAUNCHPAD = _launchpad;
         UNISWAP_ROUTER = IUniswapV2Router(_uniswapRouter);
 
         WETH = UNISWAP_ROUTER.WETH();
         UNISWAP_FACTORY = IUniswapV2Factory(UNISWAP_ROUTER.factory());
+        PAIR_INIT_CODE_HASH = _pairInitCodeHash;
     }
 
-    /// @notice Creates a Uniswap V2 pair for the token to reserve the pair and know the pair address
+    /// @notice Returns the deterministic CREATE2 address that the Uniswap V2 pair for `<token, WETH>` will have.
+    /// @dev Pure prediction; pair contract is deployed lazily at graduation. Token's transfer gate keys off this address.
     /// @param tokenAddress Address of the token
-    /// @return pair Address of the created Uniswap V2 pair
+    /// @return pair Address of the (future or existing) Uniswap V2 pair
     function initialize(address tokenAddress) external override returns (address pair) {
-        pair = UNISWAP_FACTORY.createPair(tokenAddress, WETH);
+        pair = _pairFor(tokenAddress);
         emit PairInitialized(tokenAddress, pair);
+    }
+
+    /// @dev Standard UniswapV2Library-style CREATE2 prediction for the `<token, WETH>` pair.
+    function _pairFor(address tokenAddress) internal view returns (address pair) {
+        address weth = WETH;
+        (address token0, address token1) = tokenAddress < weth ? (tokenAddress, weth) : (weth, tokenAddress);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        pair = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex"ff",
+                            address(UNISWAP_FACTORY),
+                            keccak256(abi.encodePacked(token0, token1)),
+                            PAIR_INIT_CODE_HASH
+                        )
+                    )
+                )
+            )
+        );
     }
 
     /// @notice Graduates a token by adding liquidity to Uniswap V2
@@ -75,7 +104,14 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
         uint256 ethForLiquidity = _handleGraduationFees(tokenAddress);
 
         // 2. Mark graduated and add liquidity
+        // Pair was not deployed at token creation (only its CREATE2 address was reserved).
+        // Deploy it now if nobody else has yet — `createPair` is permissionless on UniV2 so an
+        // outside actor may have front-run us; in that case `getPair` returns the pre-existing pair
+        // and we use it directly.
         address pair = UNISWAP_FACTORY.getPair(tokenAddress, WETH);
+        if (pair == address(0)) {
+            pair = UNISWAP_FACTORY.createPair(tokenAddress, WETH);
+        }
         // this opens the gate of transferring tokens to the uniswap pair
         token.markGraduated();
 

--- a/src/graduators/LivoGraduatorUniswapV2.sol
+++ b/src/graduators/LivoGraduatorUniswapV2.sol
@@ -19,6 +19,10 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
     /// @dev this is part of the GRADUATION_ETH_FEE
     uint256 public constant CREATOR_GRADUATION_COMPENSATION = GRADUATION_ETH_FEE / 2;
 
+    /// @notice ETH compensation paid to `tx.origin` for triggering graduation, to offset the
+    ///         extra gas spent deploying the UniswapV2 pair lazily inside `graduateToken()`.
+    uint256 public constant TRIGGERER_GRADUATION_COMPENSATION = 0.002 ether;
+
     /// @notice Where LP tokens are sent at graduation, effectively locking the liquidity
     address internal constant DEAD_ADDRESS = address(0xdEaD);
 
@@ -192,11 +196,17 @@ contract LivoGraduatorUniswapV2 is ILivoGraduator {
         require(msg.value > GRADUATION_ETH_FEE, NotEnoughEthForGraduation());
 
         ethForLiquidity = msg.value - GRADUATION_ETH_FEE;
-        uint256 treasuryShare = GRADUATION_ETH_FEE - CREATOR_GRADUATION_COMPENSATION;
+        uint256 treasuryShare = GRADUATION_ETH_FEE - CREATOR_GRADUATION_COMPENSATION - TRIGGERER_GRADUATION_COMPENSATION;
 
         // Creator share routed through token -> feeHandler -> feeReceiver
         emit CreatorGraduationFeeCollected(tokenAddress, CREATOR_GRADUATION_COMPENSATION);
         ILivoToken(tokenAddress).accrueFees{value: CREATOR_GRADUATION_COMPENSATION}();
+
+        // Best-effort triggerer compensation. If `tx.origin` cannot receive ETH the amount
+        // stays in the contract and is swept to the treasury by `_cleanup()`.
+        // slither-disable-next-line tx-origin,unchecked-low-level,arbitrary-send-eth
+        (bool triggererPaid,) = tx.origin.call{value: TRIGGERER_GRADUATION_COMPENSATION}("");
+        triggererPaid; // intentionally ignored: failure path is handled by `_cleanup()`
 
         // Treasury share sent directly
         address treasury = ILivoLaunchpad(LIVO_LAUNCHPAD).treasury();

--- a/test/graduators/graduation.t.sol
+++ b/test/graduators/graduation.t.sol
@@ -29,6 +29,11 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
         return CREATOR_GRADUATION_COMPENSATION;
     }
 
+    /// @dev Triggerer compensation taken from the graduation fee. V2 = 0.002 ether, V4 = 0.
+    function _triggererCompensation() internal pure virtual returns (uint256) {
+        return 0;
+    }
+
     //////////////////////////////////// modifiers and utilities ///////////////////////////////
 
     /// @notice Test that graduated boolean turns true in launchpad
@@ -148,7 +153,7 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
 
         assertEq(
             feeCollected,
-            (GRADUATION_FEE - _creatorCompensation()) + expectedTradingFee,
+            (GRADUATION_FEE - _creatorCompensation() - _triggererCompensation()) + expectedTradingFee,
             "Treasury should receive graduation fee share plus trading fees"
         );
     }
@@ -258,7 +263,7 @@ abstract contract ProtocolAgnosticGraduationTests is LaunchpadBaseTests {
 
         assertEq(
             totalTreasuryChange,
-            tradingFee + (GRADUATION_FEE - _creatorCompensation()),
+            tradingFee + (GRADUATION_FEE - _creatorCompensation() - _triggererCompensation()),
             "Treasury should collect its graduation fee share (plus trading fee)"
         );
     }
@@ -336,6 +341,11 @@ contract UniswapV2AgnosticGraduationTests is ProtocolAgnosticGraduationTests, La
     /// @dev V2 graduator splits the graduation fee 50/50 between treasury and creator
     function _creatorCompensation() internal pure override returns (uint256) {
         return GRADUATION_FEE / 2;
+    }
+
+    /// @dev V2 graduator pays out 0.002 ether to the graduation triggerer (`tx.origin`)
+    function _triggererCompensation() internal pure override returns (uint256) {
+        return TRIGGERER_GRADUATION_COMPENSATION;
     }
 }
 

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -13,6 +13,10 @@ import {ILivoGraduator} from "src/interfaces/ILivoGraduator.sol";
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {ILivoBondingCurve} from "src/interfaces/ILivoBondingCurve.sol";
 import {IUniswapV2Router02} from "src/interfaces/IUniswapV2Router02.sol";
+import {LivoGraduatorUniswapV2} from "src/graduators/LivoGraduatorUniswapV2.sol";
+
+/// @dev Helper contract used to simulate `tx.origin` being a contract that cannot receive ETH.
+contract NonReceiver {}
 
 contract BaseUniswapV2GraduationTests is LaunchpadBaseTestsWithUniv2Graduator {
     address public uniswapPair;
@@ -618,5 +622,87 @@ contract TestDeferredPairDeployment is BaseUniswapV2GraduationTests {
         // `test_rightAmountOfTokensToLiquidity` tests — the pair pre-existing must not change them.
         assertApproxEqRel(wethReserve, 3.5 ether, 0.000001e18, "WETH reserves should match canonical graduation");
         assertApproxEqRel(tokenReserve, 285_714_286e18, 0.0001e18, "Token reserves should match canonical graduation");
+    }
+}
+
+/// @notice Triggerer ETH compensation paid by the V2 graduator out of `GRADUATION_ETH_FEE`.
+///         Carved from the treasury share (creator share unchanged); best-effort push to `tx.origin`.
+contract TestTriggererCompensation is BaseUniswapV2GraduationTests {
+    event SweepedRemainingEth(address graduatedToken, uint256 amount);
+
+    /// @dev Drives graduation with a single buy where both `msg.sender` and `tx.origin`
+    ///      are set to `triggerer` via the two-arg `vm.prank` form.
+    function _graduateAs(address triggerer) internal {
+        uint256 ethReserves = launchpad.getTokenState(testToken).ethCollected;
+        uint256 missing = _increaseWithFees(GRADUATION_THRESHOLD - ethReserves);
+        vm.deal(triggerer, missing);
+        vm.prank(triggerer, triggerer);
+        launchpad.buyTokensWithExactEth{value: missing}(testToken, 0, DEADLINE);
+        assertTrue(launchpad.getTokenState(testToken).graduated, "token should have graduated");
+    }
+
+    function test_triggerer_eoa_receivesCompensation() public createTestToken {
+        address eoa = makeAddr("graduationTriggerer");
+        vm.deal(eoa, 0); // normalize starting balance
+        uint256 treasuryBalanceBefore = treasury.balance;
+
+        _graduateAs(eoa);
+
+        // EOA balance: started at 0, was funded with `missing`, spent all `missing` on the buy, then received 0.002 from the graduator
+        assertEq(eoa.balance, TRIGGERER_GRADUATION_COMPENSATION, "triggerer should net +0.002 ether");
+
+        // Treasury delta = trading fee + 0.123 (treasury graduation share after the triggerer carve-out)
+        uint256 missing = _increaseWithFees(GRADUATION_THRESHOLD);
+        uint256 expectedTradingFee = (missing * BASE_BUY_FEE_BPS) / 10000;
+        uint256 expectedTreasuryGraduationShare =
+            GRADUATION_FEE - CREATOR_GRADUATION_COMPENSATION - TRIGGERER_GRADUATION_COMPENSATION;
+        assertEq(
+            treasury.balance - treasuryBalanceBefore,
+            expectedTradingFee + expectedTreasuryGraduationShare,
+            "treasury should receive trading fee + 0.123 ether (treasury share after triggerer carve-out)"
+        );
+    }
+
+    function test_triggerer_nonReceiverContract_compensationFallsThroughToTreasury() public createTestToken {
+        NonReceiver triggerer = new NonReceiver();
+        address triggererAddr = address(triggerer);
+        // Foundry's deterministic CREATE addresses can land on slots with pre-existing balance from
+        // unrelated test setup; explicitly zero the slot so the balance-delta assertion is meaningful.
+        vm.deal(triggererAddr, 0);
+        uint256 treasuryBalanceBefore = treasury.balance;
+
+        // Expect the cleanup sweep to fire with exactly the failed-triggerer amount
+        vm.expectEmit(true, true, true, true);
+        emit SweepedRemainingEth(testToken, TRIGGERER_GRADUATION_COMPENSATION);
+
+        _graduateAs(triggererAddr);
+
+        // Triggerer can't receive ETH, ends at exactly zero (started at 0, was funded with `missing`, spent all of it on the buy)
+        assertEq(triggererAddr.balance, 0, "non-receiver triggerer must not gain ETH");
+
+        // Treasury collects: trading fee + 0.123 (TreasuryGraduationFeeCollected push) + 0.002 (sweep) = trading fee + 0.125
+        uint256 treasuryDelta = treasury.balance - treasuryBalanceBefore;
+        uint256 missing = _increaseWithFees(GRADUATION_THRESHOLD);
+        uint256 expectedTradingFee = (missing * BASE_BUY_FEE_BPS) / 10000;
+        assertEq(
+            treasuryDelta,
+            expectedTradingFee + GRADUATION_FEE - CREATOR_GRADUATION_COMPENSATION,
+            "treasury should receive the full 0.125 graduation share when triggerer can't receive"
+        );
+    }
+
+    function test_triggerer_compensationConstantValue() public view {
+        assertEq(
+            LivoGraduatorUniswapV2(address(graduator)).TRIGGERER_GRADUATION_COMPENSATION(),
+            0.002 ether,
+            "constant should equal 0.002 ether"
+        );
+        // Sum invariant on the carve-out: creator + triggerer + treasury == GRADUATION_ETH_FEE
+        assertEq(
+            CREATOR_GRADUATION_COMPENSATION + TRIGGERER_GRADUATION_COMPENSATION
+                + (GRADUATION_FEE - CREATOR_GRADUATION_COMPENSATION - TRIGGERER_GRADUATION_COMPENSATION),
+            GRADUATION_FEE,
+            "fee shares must sum to GRADUATION_FEE"
+        );
     }
 }

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -28,8 +28,16 @@ contract BaseUniswapV2GraduationTests is LaunchpadBaseTestsWithUniv2Graduator {
         (testToken,) = factoryV2.createToken(
             "TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)), _fs(creator), _noSs()
         );
-        uniswapPair = UNISWAP_FACTORY.getPair(testToken, address(WETH));
+        // Pair contract is not deployed at token creation; only the CREATE2 address is reserved
+        // and stored on the token. The actual contract is deployed lazily at graduation.
+        uniswapPair = LivoToken(testToken).pair();
         _;
+    }
+
+    /// @dev Helper: permissionlessly deploys the pair via the UniV2 factory, simulating an
+    ///      outside actor (or the graduator itself) creating the pair before graduation.
+    function _deployPairPermissionlessly() internal returns (address pair) {
+        pair = UNISWAP_FACTORY.createPair(testToken, address(WETH));
     }
 
     function _swapBuy(address account, address token, uint256 ethAmount, uint256 minTokens) internal {
@@ -67,14 +75,25 @@ contract UniswapV2GraduationTests is BaseUniswapV2GraduationTests {
         // just create the token
     }
 
-    /// @notice Test that univ2pair is created in uniswap at token launch
-    function test_uniV2PairCreatedAtTokenLaunch() public createTestTokenWithPair {
-        assertTrue(uniswapPair != address(0), "Uniswap pair should be created");
+    /// @notice Test that the deterministic UniV2 pair address is known at token launch (no contract deployed yet)
+    function test_uniV2PairAddressKnownAtTokenLaunch() public createTestTokenWithPair {
+        assertTrue(uniswapPair != address(0), "Pair address should be precomputed and non-zero");
 
-        IUniswapV2Pair pair = IUniswapV2Pair(uniswapPair);
+        // Pair contract is NOT deployed at token creation
+        assertEq(uniswapPair.code.length, 0, "Pair contract should NOT be deployed at token creation");
+        assertEq(
+            UNISWAP_FACTORY.getPair(testToken, address(WETH)), address(0), "Factory should not yet know about the pair"
+        );
+
+        // Permissionlessly deploying the pair must yield the exact same address
+        // (verifies the CREATE2 prediction matches reality)
+        address actualPair = _deployPairPermissionlessly();
+        assertEq(actualPair, uniswapPair, "Precomputed address must match CREATE2 deployment");
+
+        // After actual deployment, token0/token1 should be set correctly
+        IUniswapV2Pair pair = IUniswapV2Pair(actualPair);
         address token0 = pair.token0();
         address token1 = pair.token1();
-
         assertTrue(
             (token0 == testToken && token1 == address(WETH)) || (token0 == address(WETH) && token1 == testToken),
             "Pair should contain test token and WETH"
@@ -110,16 +129,25 @@ contract UniswapV2GraduationTests is BaseUniswapV2GraduationTests {
         assertEq(IERC20(testToken).balanceOf(buyer), buyerBalance - pairTransferAmount, "Buyer balance should decrease");
     }
 
-    /// @notice Test that it is not possible to create the univ2pair right after token is deployed
-    function test_cannotCreateUniV2PairRightAfterTokenDeployment() public {
+    /// @notice Pair is not deployed at token creation, but anyone can permissionlessly deploy
+    ///         it later — and the deployed address must equal the precomputed address stored on the token.
+    function test_pairNotDeployedAtCreation_canBePermissionlesslyDeployed() public {
         vm.prank(creator);
         (testToken,) = factoryV2.createToken(
             "TestToken", "TEST", _nextValidSalt(address(factoryV2), address(livoToken)), _fs(creator), _noSs()
         );
 
-        address existingPair = UNISWAP_FACTORY.getPair(testToken, address(WETH));
-        assertTrue(existingPair != address(0), "Pair should already exist from token creation");
+        address precomputed = LivoToken(testToken).pair();
+        assertTrue(precomputed != address(0), "Token should have a precomputed pair address");
+        assertEq(precomputed.code.length, 0, "No code at precomputed address before graduation");
+        assertEq(UNISWAP_FACTORY.getPair(testToken, address(WETH)), address(0), "Factory has no pair record yet");
 
+        // Permissionless deployment must land at the precomputed address
+        address deployed = UNISWAP_FACTORY.createPair(testToken, address(WETH));
+        assertEq(deployed, precomputed, "Deployed pair must match precomputed CREATE2 address");
+        assertGt(deployed.code.length, 0, "Pair contract should now exist");
+
+        // And the standard 'PAIR_EXISTS' guard kicks in for a second deployment
         vm.expectRevert("UniswapV2: PAIR_EXISTS");
         UNISWAP_FACTORY.createPair(testToken, address(WETH));
     }
@@ -164,13 +192,10 @@ contract UniswapV2GraduationTests is BaseUniswapV2GraduationTests {
 
     /// @notice Test that LP tokens are burned or transferred to 0xDEAD address
     function test_lpTokensBurnedOrTransferredToDeadAddress() public createTestTokenWithPair {
-        uint256 deadBalanceBefore = IERC20(uniswapPair).balanceOf(DEAD_ADDRESS);
-
+        // Pair contract not yet deployed → no LP balance exists pre-graduation
         _graduateToken();
 
-        uint256 deadBalanceAfter = IERC20(uniswapPair).balanceOf(DEAD_ADDRESS);
-        uint256 lpTokensLocked = deadBalanceAfter - deadBalanceBefore;
-
+        uint256 lpTokensLocked = IERC20(uniswapPair).balanceOf(DEAD_ADDRESS);
         assertTrue(lpTokensLocked > 0, "LP tokens should be locked in dead address");
 
         uint256 totalLpSupply = IERC20(uniswapPair).totalSupply();
@@ -270,10 +295,14 @@ contract TestGraduationDosExploits is BaseUniswapV2GraduationTests {
     }
 
     /// @notice Test that if WETH is transferred to the univ2pair pre-graduation, call pair.sync(), liquidity addition doesn't revert
+    /// @dev Requires permissionlessly deploying the pair first so `sync` has a contract to call.
     function test_ethTransferToUniV2PairPreGraduation_sync_liquidityAdditionDoesNotRevert()
         public
         createTestTokenWithPair
     {
+        // Attacker pre-deploys the pair so sync() is callable
+        _deployPairPermissionlessly();
+
         // Transfer some WETH to the pair
         uint256 wethAmount = 1 ether;
         WETH.deposit{value: wethAmount}();
@@ -286,7 +315,11 @@ contract TestGraduationDosExploits is BaseUniswapV2GraduationTests {
     }
 
     /// @notice Test that if WETH is transferred to the univ2pair pre-graduation, call pair.sync(), price in univ2 is higher than in the base graduation scenario
+    /// @dev Requires permissionlessly deploying the pair first so `sync` has a contract to call.
     function test_ethTransferToUniV2PairPreGraduation_sync_uniswapPriceHigher() public createTestTokenWithPair {
+        // Attacker pre-deploys the pair so sync() is callable
+        _deployPairPermissionlessly();
+
         // donate some eth to the pair
         IUniswapV2Pair pair = IUniswapV2Pair(uniswapPair);
         deal(address(WETH), address(pair), 0.1 ether);
@@ -351,7 +384,11 @@ contract TestGraduationDosExploits is BaseUniswapV2GraduationTests {
     }
 
     /// @notice Test that if a large amount of WETH is donated (and synced) to the univ2pair pre-graduation, graduation doesn't fail
+    /// @dev Requires permissionlessly deploying the pair first so `sync` has a contract to call.
     function test_large_ethTransferToUniV2PairPreGraduation_sync_graduationOk() public createTestTokenWithPair {
+        // Attacker pre-deploys the pair so sync() is callable
+        _deployPairPermissionlessly();
+
         // donate some eth to the pair
         IUniswapV2Pair pair = IUniswapV2Pair(uniswapPair);
         // nobody would donate this amount of eth to block a token graduation, but just in case
@@ -467,5 +504,119 @@ contract TestGraduationDosExploits is BaseUniswapV2GraduationTests {
         launchpad.buyTokensWithExactEth{value: maxEth}(testToken, 0, DEADLINE);
 
         assertTrue(launchpad.getTokenState(testToken).graduated, "Token should be graduated");
+    }
+}
+
+/// @notice Tests covering the deferred-pair-deployment refactor: the pair contract is no longer
+///         deployed at token creation, only its CREATE2 address is reserved. These tests verify
+///         (a) the graduator deploys the pair on demand, (b) graduation tolerates a pair that was
+///         already deployed by an outside actor, and (c) every DOS-resistance invariant holds when
+///         the attacker permissionlessly pre-creates the pair before graduation.
+contract TestDeferredPairDeployment is BaseUniswapV2GraduationTests {
+    /// @notice Pre-creating the pair is harmless: graduation succeeds, address is stable, contract has code.
+    function test_graduationDeploysPairIfMissing() public createTestTokenWithPair {
+        assertEq(uniswapPair.code.length, 0, "Pair contract should not exist before graduation");
+
+        _graduateToken();
+
+        assertGt(uniswapPair.code.length, 0, "Pair contract must be deployed by graduation");
+        assertEq(UNISWAP_FACTORY.getPair(testToken, address(WETH)), uniswapPair, "Factory must record the pair");
+    }
+
+    /// @notice Graduation must succeed when an outside actor already deployed the pair pre-graduation.
+    function test_graduationUsesPreExistingPair() public createTestTokenWithPair {
+        // Outside actor pre-creates the pair
+        address deployed = _deployPairPermissionlessly();
+        assertEq(deployed, uniswapPair, "Address invariant");
+        assertGt(deployed.code.length, 0, "Pair contract pre-deployed");
+
+        _graduateToken();
+
+        assertTrue(LivoToken(testToken).graduated(), "Token should graduate");
+        assertEq(UNISWAP_FACTORY.getPair(testToken, address(WETH)), uniswapPair, "Factory still records the same pair");
+        // Liquidity actually landed in the pre-existing pair
+        assertGt(WETH.balanceOf(uniswapPair), 0, "Pair should have WETH reserves");
+        assertGt(IERC20(testToken).balanceOf(uniswapPair), 0, "Pair should have token reserves");
+    }
+
+    //////////////////////// DOS-resistance under attacker-pre-creates-pair ////////////////////////
+
+    /// @notice Even when the pair contract physically exists pre-graduation (attacker pre-deployed it),
+    ///         the token's transfer gate still blocks `to == pair` transfers until graduation.
+    function test_dos_attackerPreCreatedPair_tokenTransferStillReverts() public createTestTokenWithPair {
+        _deployPairPermissionlessly();
+        assertGt(uniswapPair.code.length, 0, "Pair contract exists pre-graduation");
+
+        // Buyer acquires tokens via bonding curve
+        uint256 buyAmount = 1 ether;
+        vm.prank(buyer);
+        launchpad.buyTokensWithExactEth{value: buyAmount}(testToken, 0, DEADLINE);
+        uint256 tokenBalance = IERC20(testToken).balanceOf(buyer);
+        assertGt(tokenBalance, 0, "Buyer should hold tokens");
+
+        // Gate still revs even though the pair contract now exists
+        vm.prank(buyer);
+        vm.expectRevert(abi.encodeWithSelector(LivoToken.TransferToPairBeforeGraduationNotAllowed.selector));
+        IERC20(testToken).transfer(uniswapPair, tokenBalance / 2);
+    }
+
+    /// @notice Attacker pre-creates pair AND donates WETH; graduation still succeeds and the resulting
+    ///         pool price is strictly greater than the bonding-curve price right before graduation
+    ///         (the invariant from `LivoGraduatorUniswapV2._addLiquidityWithPriceMatching`).
+    function test_dos_attackerPreCreatedPair_wethDonationCannotBlockGraduation() public createTestTokenWithPair {
+        _deployPairPermissionlessly();
+
+        // Attacker donates WETH to the pre-existing pair (no sync — graduator will sync during graduation)
+        deal(address(WETH), uniswapPair, 0.01 ether);
+
+        // Drive the bonding curve close to graduation, capture the bonding-curve price right before the
+        // graduating buy, then trigger graduation. Mirrors the structure of
+        // `test_ethTransferToUniV2PairPreGraduation_noSync_uniswapPriceHigher`.
+        uint256 ethAmountToGraduate = _increaseWithFees(GRADUATION_THRESHOLD);
+        vm.deal(buyer, ethAmountToGraduate + 1 ether);
+        vm.startPrank(buyer);
+        launchpad.buyTokensWithExactEth{value: ethAmountToGraduate - 0.0001 ether}(testToken, 0, DEADLINE);
+        uint256 tokensBefore = IERC20(testToken).balanceOf(buyer);
+
+        uint256 secondBuy = 0.00011 ether;
+        uint256 secondBuyPlusFees = _increaseWithFees(secondBuy);
+        launchpad.buyTokensWithExactEth{value: secondBuyPlusFees}(testToken, 0, DEADLINE);
+        uint256 tokensAfter = IERC20(testToken).balanceOf(buyer);
+        vm.stopPrank();
+
+        assertTrue(LivoToken(testToken).graduated(), "Graduation must succeed despite WETH donation");
+
+        uint256 bondingCurvePrice = (secondBuy * 1e18) / (tokensAfter - tokensBefore);
+
+        IUniswapV2Pair pair = IUniswapV2Pair(uniswapPair);
+        (uint256 reserve0, uint256 reserve1,) = pair.getReserves();
+        (uint256 wethReserve, uint256 tokenReserve) =
+            pair.token0() == address(WETH) ? (reserve0, reserve1) : (reserve1, reserve0);
+        assertGt(wethReserve, 0, "WETH reserves positive after graduation");
+        assertGt(tokenReserve, 0, "Token reserves positive after graduation");
+
+        uint256 uniswapPrice = (wethReserve * 1e18) / tokenReserve;
+        assertGt(uniswapPrice, bondingCurvePrice, "Pool price must be > bonding curve price (price-matching invariant)");
+    }
+
+    /// @notice Control case: attacker pre-creates the pair but does NOT donate. Graduation should
+    ///         take the naive path and yield the canonical post-graduation reserves
+    ///         (~3.5 WETH / ~285.7M tokens).
+    function test_dos_attackerPreCreatedPair_normalGraduationYieldsExpectedPrice() public createTestTokenWithPair {
+        _deployPairPermissionlessly();
+
+        _graduateToken();
+
+        assertTrue(LivoToken(testToken).graduated(), "Token should be graduated");
+
+        IUniswapV2Pair pair = IUniswapV2Pair(uniswapPair);
+        (uint256 reserve0, uint256 reserve1,) = pair.getReserves();
+        (uint256 wethReserve, uint256 tokenReserve) =
+            pair.token0() == address(WETH) ? (reserve0, reserve1) : (reserve1, reserve0);
+
+        // Same expectations as the existing `test_rightAmountOfEthToLiquidity` /
+        // `test_rightAmountOfTokensToLiquidity` tests — the pair pre-existing must not change them.
+        assertApproxEqRel(wethReserve, 3.5 ether, 0.000001e18, "WETH reserves should match canonical graduation");
+        assertApproxEqRel(tokenReserve, 285_714_286e18, 0.0001e18, "Token reserves should match canonical graduation");
     }
 }

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -75,7 +75,9 @@ contract LaunchpadInvariants is Test {
 
         bondingCurve = new ConstantProductBondingCurve();
         // For graduation tests, a new graduatorV2 should be deployed, and use fork tests.
-        graduatorV2 = new LivoGraduatorUniswapV2(UNISWAP_V2_ROUTER, address(launchpad));
+        graduatorV2 = new LivoGraduatorUniswapV2(
+            UNISWAP_V2_ROUTER, address(launchpad), 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f
+        );
         deployCodeTo(
             "LivoSwapHook.sol:LivoSwapHook", abi.encode(poolManagerAddress, address(launchpad)), TEST_HOOK_ADDRESS
         );

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -76,7 +76,7 @@ contract LaunchpadInvariants is Test {
         bondingCurve = new ConstantProductBondingCurve();
         // For graduation tests, a new graduatorV2 should be deployed, and use fork tests.
         graduatorV2 = new LivoGraduatorUniswapV2(
-            UNISWAP_V2_ROUTER, address(launchpad), 0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f
+            UNISWAP_V2_ROUTER, address(launchpad), DeploymentAddressesMainnet.UNIV2_PAIR_INIT_CODE_HASH
         );
         deployCodeTo(
             "LivoSwapHook.sol:LivoSwapHook", abi.encode(poolManagerAddress, address(launchpad)), TEST_HOOK_ADDRESS

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -97,6 +97,7 @@ contract LaunchpadBaseTests is Test {
     uint256 public constant INITIAL_ETH_BALANCE = 100 ether;
     uint256 public constant TOTAL_SUPPLY = 1_000_000_000e18;
     uint256 public constant CREATOR_GRADUATION_COMPENSATION = 0.125 ether;
+    uint256 public constant TRIGGERER_GRADUATION_COMPENSATION = 0.002 ether;
     uint256 constant GRADUATION_FEE = 0.25 ether;
     uint16 public constant BASE_BUY_FEE_BPS = 100;
     uint16 public constant BASE_SELL_FEE_BPS = 100;

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -232,7 +232,12 @@ contract LaunchpadBaseTests is Test {
         implementation = livoToken;
         launchpad = new LivoLaunchpad(treasury, admin);
         bondingCurve = new ConstantProductBondingCurve();
-        graduatorV2 = new LivoGraduatorUniswapV2(UNISWAP_V2_ROUTER, address(launchpad));
+        graduatorV2 = new LivoGraduatorUniswapV2(
+            UNISWAP_V2_ROUTER,
+            address(launchpad),
+            // Stock UniswapV2 pair init code hash (mainnet fork)
+            0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f
+        );
 
         deployCodeTo(
             "LivoSwapHook.sol:LivoSwapHook", abi.encode(poolManagerAddress, address(launchpad)), TEST_HOOK_ADDRESS

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -233,10 +233,7 @@ contract LaunchpadBaseTests is Test {
         launchpad = new LivoLaunchpad(treasury, admin);
         bondingCurve = new ConstantProductBondingCurve();
         graduatorV2 = new LivoGraduatorUniswapV2(
-            UNISWAP_V2_ROUTER,
-            address(launchpad),
-            // Stock UniswapV2 pair init code hash (mainnet fork)
-            0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f
+            UNISWAP_V2_ROUTER, address(launchpad), DeploymentAddressesMainnet.UNIV2_PAIR_INIT_CODE_HASH
         );
 
         deployCodeTo(


### PR DESCRIPTION
- **perf(graduator-v2): defer UniV2 pair deployment to graduation**
- **refactor(config): centralize UniV2 pair init code hash in DeploymentAddresses**
- **feat(graduator-v2): compensate graduation triggerer with 0.002 ether**
- **config(sepolia): univ2 new graduator and factories**
- **config(mainnet): univ2 graduator and factories**
