### PR TITLE
feat(taxes): direct V2 fee path, receive()-based routing, decrease-only setTaxBps

### DIFF
--- a/abis/ILivoTaxableToken.json
+++ b/abis/ILivoTaxableToken.json
@@ -369,6 +369,24 @@
   },
   {
     "type": "function",
+    "name": "setTaxBps",
+    "inputs": [
+      {
+        "name": "newBuyTaxBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "newSellTaxBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "totalSupply",
     "inputs": [],
     "outputs": [

--- a/abis/ILivoTaxableToken.json
+++ b/abis/ILivoTaxableToken.json
@@ -95,24 +95,6 @@
   },
   {
     "type": "function",
-    "name": "getFeeReceivers",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "receivers",
-        "type": "address[]",
-        "internalType": "address[]"
-      },
-      {
-        "name": "sharesBps",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getTaxConfig",
     "inputs": [],
     "outputs": [
@@ -369,6 +351,19 @@
   },
   {
     "type": "function",
+    "name": "setFeeHandler",
+    "inputs": [
+      {
+        "name": "newFeeHandler",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setTaxBps",
     "inputs": [
       {
@@ -472,6 +467,25 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeHandlerChanged",
+    "inputs": [
+      {
+        "name": "oldFeeHandler",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newFeeHandler",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       }
     ],
     "anonymous": false

--- a/abis/ILivoToken.json
+++ b/abis/ILivoToken.json
@@ -95,24 +95,6 @@
   },
   {
     "type": "function",
-    "name": "getFeeReceivers",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "receivers",
-        "type": "address[]",
-        "internalType": "address[]"
-      },
-      {
-        "name": "sharesBps",
-        "type": "uint256[]",
-        "internalType": "uint256[]"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "getTaxConfig",
     "inputs": [],
     "outputs": [
@@ -289,6 +271,19 @@
   },
   {
     "type": "function",
+    "name": "setFeeHandler",
+    "inputs": [
+      {
+        "name": "newFeeHandler",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "totalSupply",
     "inputs": [],
     "outputs": [
@@ -374,6 +369,25 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeHandlerChanged",
+    "inputs": [
+      {
+        "name": "oldFeeHandler",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newFeeHandler",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
       }
     ],
     "anonymous": false

--- a/abis/LivoFactoryUniV2Unified.json
+++ b/abis/LivoFactoryUniV2Unified.json
@@ -555,6 +555,25 @@
   },
   {
     "type": "event",
+    "name": "DirectSingleFeeReceiver",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Initialized",
     "inputs": [
       {

--- a/abis/LivoFactoryUniV2Unified.json
+++ b/abis/LivoFactoryUniV2Unified.json
@@ -99,19 +99,6 @@
   },
   {
     "type": "function",
-    "name": "MAX_CHARITY_TAX_DURATION_SECONDS",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "MAX_TAX_BPS",
     "inputs": [],
     "outputs": [
@@ -190,10 +177,16 @@
   },
   {
     "type": "function",
-    "name": "acceptOwnership",
+    "name": "UPGRADE_INTERFACE_VERSION",
     "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -314,6 +307,13 @@
   },
   {
     "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "maxBuyOnDeployBps",
     "inputs": [],
     "outputs": [
@@ -340,23 +340,10 @@
   },
   {
     "type": "function",
-    "name": "pendingOwner",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "previewTokenImplementation",
     "inputs": [
       {
-        "name": "feeReceivers",
+        "name": "",
         "type": "tuple[]",
         "internalType": "struct ILivoFactory.FeeShare[]",
         "components": [
@@ -455,6 +442,19 @@
   },
   {
     "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "quoteBuyOnDeploy",
     "inputs": [
       {
@@ -481,19 +481,6 @@
   },
   {
     "type": "function",
-    "name": "setMaxBuyOnDeployBps",
-    "inputs": [
-      {
-        "name": "newMaxBuyOnDeployBps",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "transferOwnership",
     "inputs": [
       {
@@ -504,6 +491,24 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
     "type": "event",
@@ -550,32 +555,13 @@
   },
   {
     "type": "event",
-    "name": "MaxBuyOnDeployBpsUpdated",
+    "name": "Initialized",
     "inputs": [
       {
-        "name": "newMaxBuyOnDeployBps",
-        "type": "uint256",
+        "name": "version",
+        "type": "uint64",
         "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OwnershipTransferStarted",
-    "inputs": [
-      {
-        "name": "previousOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        "internalType": "uint64"
       }
     ],
     "anonymous": false
@@ -649,18 +635,53 @@
     "anonymous": false
   },
   {
-    "type": "error",
-    "name": "CharityModeFeeReceiverInvalid",
-    "inputs": []
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "error",
-    "name": "CharityModeOwnerNotRenounced",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
     "inputs": []
   },
   {
     "type": "error",
     "name": "FailedDeployment",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
     "inputs": []
   },
   {
@@ -696,7 +717,7 @@
   },
   {
     "type": "error",
-    "name": "InvalidMaxBuyOnDeployBps",
+    "name": "InvalidInitialization",
     "inputs": []
   },
   {
@@ -746,6 +767,11 @@
   },
   {
     "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
       {
@@ -774,6 +800,22 @@
         "name": "token",
         "type": "address",
         "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ]
   }

--- a/abis/LivoFactoryUniV4Unified.json
+++ b/abis/LivoFactoryUniV4Unified.json
@@ -560,6 +560,25 @@
   },
   {
     "type": "event",
+    "name": "DirectSingleFeeReceiver",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "Initialized",
     "inputs": [
       {

--- a/abis/LivoFactoryUniV4Unified.json
+++ b/abis/LivoFactoryUniV4Unified.json
@@ -99,19 +99,6 @@
   },
   {
     "type": "function",
-    "name": "MAX_CHARITY_TAX_DURATION_SECONDS",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "MAX_TAX_BPS",
     "inputs": [],
     "outputs": [
@@ -190,10 +177,16 @@
   },
   {
     "type": "function",
-    "name": "acceptOwnership",
+    "name": "UPGRADE_INTERFACE_VERSION",
     "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -319,6 +312,13 @@
   },
   {
     "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "maxBuyOnDeployBps",
     "inputs": [],
     "outputs": [
@@ -345,23 +345,10 @@
   },
   {
     "type": "function",
-    "name": "pendingOwner",
-    "inputs": [],
-    "outputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
     "name": "previewTokenImplementation",
     "inputs": [
       {
-        "name": "feeReceivers",
+        "name": "",
         "type": "tuple[]",
         "internalType": "struct ILivoFactory.FeeShare[]",
         "components": [
@@ -460,6 +447,19 @@
   },
   {
     "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "quoteBuyOnDeploy",
     "inputs": [
       {
@@ -486,19 +486,6 @@
   },
   {
     "type": "function",
-    "name": "setMaxBuyOnDeployBps",
-    "inputs": [
-      {
-        "name": "newMaxBuyOnDeployBps",
-        "type": "uint256",
-        "internalType": "uint256"
-      }
-    ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "transferOwnership",
     "inputs": [
       {
@@ -509,6 +496,24 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
   },
   {
     "type": "event",
@@ -555,32 +560,13 @@
   },
   {
     "type": "event",
-    "name": "MaxBuyOnDeployBpsUpdated",
+    "name": "Initialized",
     "inputs": [
       {
-        "name": "newMaxBuyOnDeployBps",
-        "type": "uint256",
+        "name": "version",
+        "type": "uint64",
         "indexed": false,
-        "internalType": "uint256"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "OwnershipTransferStarted",
-    "inputs": [
-      {
-        "name": "previousOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "newOwner",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
+        "internalType": "uint64"
       }
     ],
     "anonymous": false
@@ -654,18 +640,53 @@
     "anonymous": false
   },
   {
-    "type": "error",
-    "name": "CharityModeFeeReceiverInvalid",
-    "inputs": []
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "error",
-    "name": "CharityModeOwnerNotRenounced",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
     "inputs": []
   },
   {
     "type": "error",
     "name": "FailedDeployment",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedInnerCall",
     "inputs": []
   },
   {
@@ -701,7 +722,7 @@
   },
   {
     "type": "error",
-    "name": "InvalidMaxBuyOnDeployBps",
+    "name": "InvalidInitialization",
     "inputs": []
   },
   {
@@ -751,6 +772,11 @@
   },
   {
     "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "OwnableInvalidOwner",
     "inputs": [
       {
@@ -779,6 +805,22 @@
         "name": "token",
         "type": "address",
         "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ]
   }

--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23` |
 | LivoGraduatorUniswapV2                       | `0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC` |
 | LivoGraduatorUniswapV4                       | `0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944` |
-| LivoMasterFeeHandler                         | `0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC` |
+| LivoMasterFeeHandler                         | `0x48b3F72469cDba3986A36cE6C47e6Cb027dCCcF2` |
 | LivoSwapHook                                 | `0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc` |
 | LivoQuoter                                   | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
 | LivoToken (impl)                             | `0x79E3a3473ad2d9285A7C87ACfb4A5C871396240d` |

--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -13,16 +13,16 @@
 | LivoMasterFeeHandler                         | `0x48b3F72469cDba3986A36cE6C47e6Cb027dCCcF2` |
 | LivoSwapHook                                 | `0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc` |
 | LivoQuoter                                   | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
-| LivoToken (impl)                             | `0x79E3a3473ad2d9285A7C87ACfb4A5C871396240d` |
-| LivoTaxableTokenUniV4 (impl)                 | `0xF232d7D7B552B3B981FE91B13F715B3c1F075A13` |
-| LivoTokenSniperProtected (impl)              | `0xA6d75e290b12f6c2E90C82bF431bBEb4EF5D4862` |
-| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x95A52bF07bAB218712b66148D48B2EaD44610dE7` |
-| LivoTaxableTokenUniV2 (impl)                 | `0xfb536Abb27f52DBb62DD91f789C6B9a12C48441b` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0xE8296eC8061af577DD1f06263E9B07A35d6a084F` |
+| LivoToken (impl)                             | `0x974F9139D56DAE3D44714Cd24632BB9Bf69139E2` |
+| LivoTaxableTokenUniV4 (impl)                 | `0x805bE40375F5263321Be2B1B16524709F0FE5726` |
+| LivoTokenSniperProtected (impl)              | `0xeebA991E97304a10c3409495F6DFbB0f7CA5fAe5` |
+| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x8907cA768EcaCbBb7D2209FEE6b190EA71124A12` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x87d412A2f3976B7933D8a73858218B7147775e2A` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x1d20ae8983E44DBCcAF947a8f9998835E07573D3` |
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
-| LivoFactoryUniV2Unified (impl)               | `0x6Cc0EC8f989bd39A472D0690e24d5249a3642Eb4` |
+| LivoFactoryUniV2Unified (impl)               | `0x14634CBf79c4432E75E1494B8D58984FaD4e4fEE` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0x944f141Cd97c5126D118Df2d0f36867a1D63B186` |
+| LivoFactoryUniV4Unified (impl)               | `0x41241EcD235cd7e0e35a6c79Ba235C1D8BD7DffC` |
 
 ## Accounts
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -17,10 +17,10 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x57Bb01ac46B9a2DfC3C05cE47d692e4b729BDCBe` |
 | LivoTokenSniperProtected (impl)              | `0xdF5CD2fc0078147Fce85bc2170250eC6339026a0` |
 | LivoTaxableTokenUniV4SniperProtected (impl)  | `0x8289D631513B3766D79820682b864a47923c60a0` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x6b7E55f0Dc9C5841A5bACDDCf23ccDcb28afd040` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0xAF58def3c5663716016Ffa7C9f6f69B359cDE4D8` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x25d2F64271B9f5715eE7D1359e1A290cc208410F` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x5AF555eCB77fB9ff165D38170a3917D90B57084c` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0x279C76a0D562D597eFa8f2C811210AF4fFB68F51` |
+| LivoFactoryUniV2Unified (impl)               | `0x25413997d736C7cb7D044A6A6983420dB00Ef8f8` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
 | LivoFactoryUniV4Unified (impl)               | `0x9bd879588A942308bee973B79311680266B85707` |
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -17,10 +17,10 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x57Bb01ac46B9a2DfC3C05cE47d692e4b729BDCBe` |
 | LivoTokenSniperProtected (impl)              | `0xdF5CD2fc0078147Fce85bc2170250eC6339026a0` |
 | LivoTaxableTokenUniV4SniperProtected (impl)  | `0x8289D631513B3766D79820682b864a47923c60a0` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x25d2F64271B9f5715eE7D1359e1A290cc208410F` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x5AF555eCB77fB9ff165D38170a3917D90B57084c` |
+| LivoTaxableTokenUniV2 (impl)                 | `0xE9081F5db8D4ac5193eD4D987B93A54916175Fa7` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x7bF9a2098DC5DC0bBD22552372a8DEDE37751903` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0x25413997d736C7cb7D044A6A6983420dB00Ef8f8` |
+| LivoFactoryUniV2Unified (impl)               | `0x63495eE6A0044F263ACA029e1432930c124e91da` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
 | LivoFactoryUniV4Unified (impl)               | `0x9bd879588A942308bee973B79311680266B85707` |
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -13,16 +13,16 @@
 | LivoMasterFeeHandler                         | `0x3dD70c06e04A10768aAd7208f119e73E4eD3e306` |
 | LivoSwapHook                                 | `0x0591a87D3a56797812C4DA164C1B005c545400Cc` |
 | LivoQuoter                                   | `0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438` |
-| LivoToken (impl)                             | `0x2C0a167A0f83E7969cA22B386Fe72BA608af9B4a` |
-| LivoTaxableTokenUniV4 (impl)                 | `0xCcc99765d31A6023E279b98f19e3dFB8430D401f` |
-| LivoTokenSniperProtected (impl)              | `0xE90318026ea1D2865A5359386a75B75acB054B52` |
-| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x791A685EDCE8839C29Fe87Ad8b4ea84E3D1d98C0` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x90FcBc67563B6e6950439a28D32964a47503Eb35` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x9d73bb0fF3DbdCd727fD84E8CB424Ad83920C202` |
+| LivoToken (impl)                             | `0x7A2F3A309f070c8F45E541e1069BaEF5dA7A1512` |
+| LivoTaxableTokenUniV4 (impl)                 | `0x57Bb01ac46B9a2DfC3C05cE47d692e4b729BDCBe` |
+| LivoTokenSniperProtected (impl)              | `0xdF5CD2fc0078147Fce85bc2170250eC6339026a0` |
+| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x8289D631513B3766D79820682b864a47923c60a0` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x6b7E55f0Dc9C5841A5bACDDCf23ccDcb28afd040` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0xAF58def3c5663716016Ffa7C9f6f69B359cDE4D8` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0x60653929Cc5b5053e428311FD4182882244901b0` |
+| LivoFactoryUniV2Unified (impl)               | `0x279C76a0D562D597eFa8f2C811210AF4fFB68F51` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0x76133EFc6563047e9D990c902063e1746601e2D3` |
+| LivoFactoryUniV4Unified (impl)               | `0x9bd879588A942308bee973B79311680266B85707` |
 
 ## Accounts
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -17,10 +17,10 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x57Bb01ac46B9a2DfC3C05cE47d692e4b729BDCBe` |
 | LivoTokenSniperProtected (impl)              | `0xdF5CD2fc0078147Fce85bc2170250eC6339026a0` |
 | LivoTaxableTokenUniV4SniperProtected (impl)  | `0x8289D631513B3766D79820682b864a47923c60a0` |
-| LivoTaxableTokenUniV2 (impl)                 | `0xE9081F5db8D4ac5193eD4D987B93A54916175Fa7` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x7bF9a2098DC5DC0bBD22552372a8DEDE37751903` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x40C8Aa070fBAcA3467BADA8Ec6039308fd8eb462` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x2C358C8C09BA9B9a70916b8905A644f9e4A1606B` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0x63495eE6A0044F263ACA029e1432930c124e91da` |
+| LivoFactoryUniV2Unified (impl)               | `0x01bf709952FC4f7caCF98240F1C2086d56f135B7` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
 | LivoFactoryUniV4Unified (impl)               | `0x9bd879588A942308bee973B79311680266B85707` |
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5` |
 | LivoGraduatorUniswapV2                       | `0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691` |
 | LivoGraduatorUniswapV4                       | `0x85fE2051413a4b80b904f05841d1142FeF7f789c` |
-| LivoMasterFeeHandler                         | `0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f` |
+| LivoMasterFeeHandler                         | `0x3dD70c06e04A10768aAd7208f119e73E4eD3e306` |
 | LivoSwapHook                                 | `0x0591a87D3a56797812C4DA164C1B005c545400Cc` |
 | LivoQuoter                                   | `0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438` |
 | LivoToken (impl)                             | `0x2C0a167A0f83E7969cA22B386Fe72BA608af9B4a` |

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -41,6 +41,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 8. [`LivoMasterFeeHandler.setShares`](#8-livomasterfeehandlersetsharesaddress-token-feeshare-feeshares)
 9. [Direct-fee behavior](#9-direct-fee-behavior)
 10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
+11. [`LivoMasterFeeHandler.receive` (plain ETH)](#11-livomasterfeehandlerreceive-plain-eth)
 
 ---
 
@@ -100,7 +101,7 @@ Livo event order:
 1. **`LivoLaunchpad.LivoTokenBuy`** (`token, buyer, ethAmount, tokenAmount, ethFee`) — from the triggering buy.
 2. ERC20 transfer of the remaining launchpad token balance from `LivoLaunchpad` to `LivoGraduatorUniswapV2`.
 3. **`LivoGraduator.CreatorGraduationFeeCollected`** (`token, amount=creatorCompensation`).
-4. Creator compensation is routed through `LivoToken.accrueFees()` into `LivoMasterFeeHandler.depositFees(token)`:
+4. Creator compensation is routed through `LivoToken.accrueFees()` → plain ETH transfer to the master handler → handler `receive()` attributes the deposit to `msg.sender = token`:
    - **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=creatorCompensation`).
    - Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) if the configured receiver is direct and the forward succeeds.
 5. **`LivoGraduator.TreasuryGraduationFeeCollected`** (`token, amount=treasuryShare`).
@@ -121,7 +122,7 @@ Livo event order:
 1. **`LivoLaunchpad.LivoTokenBuy`** (`token, buyer, ethAmount, tokenAmount, ethFee`) — from the triggering buy.
 2. ERC20 transfer of the remaining launchpad token balance from `LivoLaunchpad` to `LivoGraduatorUniswapV4`.
 3. **`LivoGraduator.CreatorGraduationFeeCollected`** (`token, amount=creatorCompensation`).
-4. Creator compensation is routed through `LivoToken.accrueFees()` into `LivoMasterFeeHandler.depositFees(token)`:
+4. Creator compensation is routed through `LivoToken.accrueFees()` → plain ETH transfer to the master handler → handler `receive()` attributes the deposit to `msg.sender = token`:
    - **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=creatorCompensation`).
    - Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) if the configured receiver is direct and the forward succeeds.
 5. **`LivoGraduator.TreasuryGraduationFeeCollected`** (`token, amount=treasuryShare`).
@@ -158,7 +159,7 @@ Livo event order:
 
 1. **`LivoSwapHook.LpFeesAccrued`** (`token, creatorShare, treasuryShare`).
 2. Optional **`LivoSwapHook.CreatorTaxesAccrued`** (`token, taxAmount`) if buy tax is active and non-zero.
-3. Creator LP share plus any buy tax is routed through `LivoToken.accrueFees()` into `LivoMasterFeeHandler.depositFees(token)`:
+3. Creator LP share plus any buy tax is routed through `LivoToken.accrueFees()` → plain ETH transfer to the master handler → handler `receive()` attributes the deposit to `msg.sender = token`:
    - **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=creatorShare + taxAmount`).
    - Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) for each successful direct forward.
 4. Treasury LP share is sent directly via native ETH call.
@@ -172,7 +173,7 @@ Livo event order:
 
 1. **`LivoSwapHook.LpFeesAccrued`** (`token, creatorShare, treasuryShare`).
 2. Optional **`LivoSwapHook.CreatorTaxesAccrued`** (`token, taxAmount`) if sell tax is active and non-zero.
-3. Creator LP share plus any sell tax is routed through `LivoToken.accrueFees()` into `LivoMasterFeeHandler.depositFees(token)`:
+3. Creator LP share plus any sell tax is routed through `LivoToken.accrueFees()` → plain ETH transfer to the master handler → handler `receive()` attributes the deposit to `msg.sender = token`:
    - **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=creatorShare + taxAmount`).
    - Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) for each successful direct forward.
 4. Treasury LP share is sent directly via native ETH call.
@@ -189,8 +190,8 @@ Indexer-relevant points:
 - **Auto- or manual-triggered swap-back** runs `IUniswapV2Router.swapExactTokensForETHSupportingFeeOnTransferTokens` against the pair and then routes proceeds to the master fee handler. Livo event order:
   1. ERC20 transfer from `address(token)` to `pair` for the swap input.
   2. External Uniswap V2 `Sync` / `Swap` events on the pair, plus `Withdrawal` on WETH.
-  3. **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted before fees are deposited. `ethAmount` is the ETH that will be routed through `feeHandler.depositFees`, i.e. the tax accrued to the creator (and any direct receivers) for the swap window covered by this back-swap.
-  4. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=ethAmount`) emitted by `depositFees`.
+  3. **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted before fees are deposited. `ethAmount` is the ETH that the token will push to the master fee handler via a plain ETH transfer (no `depositFees` call), i.e. the tax accrued to the creator (and any direct receivers) for the swap window covered by this back-swap.
+  4. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=ethAmount`) emitted by the handler's `receive()` (attribution via `msg.sender = token`).
   5. Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) for each successful direct forward.
 - The token's `swapBack(uint256 amountOutMinWei)` external function is owner-only and produces the same event sequence as the auto-trigger only if the token has a non-zero owner. Factory-deployed V2 tokens are ownerless, so this manual path is inaccessible there.
 - Past the tax window (`block.timestamp > graduationTimestamp + taxDurationSeconds`), no tax transfer is taken and the `CreatorTaxSwapback` path is not entered.
@@ -229,7 +230,7 @@ A BPS-only rebalance with an unchanged direct set emits only `SharesUpdated`.
 
 Direct fees are configured per token through `FeeShare.directFeesEnabled` at token creation or through `LivoMasterFeeHandler.setShares`.
 
-For every successful non-zero `depositFees(token)` against a registered config:
+The same event order applies to every successful non-zero deposit, regardless of entry point (`depositFees(token)` or `receive()` via a plain ETH transfer from the token). For every such deposit against a registered config:
 
 1. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount`).
 2. For each direct receiver with a non-zero slice:
@@ -237,7 +238,7 @@ For every successful non-zero `depositFees(token)` against a registered config:
    - If the ETH forward fails, no `CreatorClaimed` event is emitted for that slice; the slice is stored as pending and can later be recovered through `claim()`.
 3. Claimable recipients do not emit per-deposit claim events; they accrue through the master handler accumulator and emit `CreatorClaimed` only when they call `claim()`.
 
-Zero-value `depositFees(token)` calls are no-ops and emit no fee events, including for unregistered tokens.
+Zero-value `depositFees(token)` (or `receive()` from a token) calls are no-ops and emit no fee events, including for unregistered tokens.
 
 ---
 
@@ -250,3 +251,19 @@ The function is decrease-only: `newBuyTaxBps` and `newSellTaxBps` must both be `
 On success:
 
 1. **`LivoTaxableToken.TaxBpsUpdated`** (`newBuyTaxBps, newSellTaxBps`) — emitted before the storage write. Old values can be reconstructed from the preceding `LivoTaxableTokenInitialized` event at creation time and the chain of any prior `TaxBpsUpdated` events.
+
+---
+
+## 11. `LivoMasterFeeHandler.receive` (plain ETH)
+
+Plain ETH transfers (empty calldata) to the master fee handler are accepted and attributed to `msg.sender`. This is the canonical path for tokens to push accrued fees: `LivoToken.accrueFees()` and the V2 swap-back path send ETH directly to the handler, no `depositFees(address)` call.
+
+Behavior is identical to `depositFees(token)` with `token = msg.sender`, including:
+- Zero-value transfers are no-ops (no event).
+- Positive-value transfers from an unregistered address revert with the same array-OOB panic as `depositFees`.
+- The `nonReentrant` transient guard is shared with `depositFees`, `setShares` and `claim`.
+
+Event order on a successful non-zero deposit:
+
+1. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token=msg.sender, amount`).
+2. For each direct receiver with a non-zero slice: optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, sliceAmount`) on a successful synchronous forward. A failed forward (including a recursive `receive()` blocked by the `nonReentrant` guard) silently records the slice as pending instead.

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -18,6 +18,8 @@ Unified factories register fee config automatically during token creation:
 
 `LivoMasterFeeHandler.registerToken` emits any initial direct-receiver events first, then `SharesUpdated`.
 
+**Direct-handler exception (V2 taxable, single direct receiver).** `LivoFactoryUniV2Unified` overrides `_resolveFeeHandlerForInit` to bake the receiver's address into `token.feeHandler` whenever the deploy uses one of the V2 taxable implementations AND `feeReceivers.length == 1` AND that receiver has `directFeesEnabled = true`. In that case `_finalizeCreation` skips `registerFees`, the master fee handler is never registered for this token, and the factory emits `DirectSingleFeeReceiver(token, receiver)` instead of the `DirectReceiverRegistered` / `SharesUpdated` pair. Swap-backs then push ETH directly to the receiver via a plain ETH transfer.
+
 ## Active event emitters covered here
 
 - `LivoFactoryUniV2Unified` / `LivoFactoryUniV4Unified`
@@ -42,6 +44,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 9. [Direct-fee behavior](#9-direct-fee-behavior)
 10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 11. [`LivoMasterFeeHandler.receive` (plain ETH)](#11-livomasterfeehandlerreceive-plain-eth)
+12. [`LivoToken.setFeeHandler`](#12-livotokensetfeehandleraddress-newfeehandler)
 
 ---
 
@@ -62,6 +65,7 @@ For both unified factories, the common Livo event order is:
 5. Initial fee config is registered through the token into `LivoMasterFeeHandler`:
    - Zero or more **`LivoMasterFeeHandler.DirectReceiverRegistered`** (`token, receiver`) — one per initial direct receiver.
    - **`LivoMasterFeeHandler.SharesUpdated`** (`token, recipients, sharesBps`).
+   - **Direct-handler path only (V2 taxable + single direct receiver):** `registerFees` is skipped entirely. Instead the factory emits a single **`LivoFactory.DirectSingleFeeReceiver`** (`token, receiver`). The master handler emits nothing for this token at deploy; `token.feeHandler() == receiver` from this point.
 
 Notes:
 
@@ -190,9 +194,11 @@ Indexer-relevant points:
 - **Auto- or manual-triggered swap-back** runs `IUniswapV2Router.swapExactTokensForETHSupportingFeeOnTransferTokens` against the pair and then routes proceeds to the master fee handler. Livo event order:
   1. ERC20 transfer from `address(token)` to `pair` for the swap input.
   2. External Uniswap V2 `Sync` / `Swap` events on the pair, plus `Withdrawal` on WETH.
-  3. **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted before fees are deposited. `ethAmount` is the ETH that the token will push to the master fee handler via a plain ETH transfer (no `depositFees` call), i.e. the tax accrued to the creator (and any direct receivers) for the swap window covered by this back-swap.
+  3. **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted before fees are deposited. `ethAmount` is the ETH that the token will push to its fee handler via a plain ETH transfer (no `depositFees` call), i.e. the tax accrued to the creator (and any direct receivers) for the swap window covered by this back-swap.
   4. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=ethAmount`) emitted by the handler's `receive()` (attribution via `msg.sender = token`).
   5. Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) for each successful direct forward.
+
+  **Direct-handler variant (V2 taxable + single direct receiver).** When the token was deployed on the direct-handler path (see §1.1), `token.feeHandler` is the receiver itself and the swap-back's plain ETH transfer never reaches the master handler. Only steps 1–3 above happen on-chain — `LivoMasterFeeHandler.CreatorFeesDeposited` and `CreatorClaimed` are NOT emitted in this variant. The indexer relies solely on `CreatorTaxSwapback` (paired with the `TokenFeeData.isDirectFeeHandlerEOA` flag set at deploy) to advance `accountedEth` + `accruedEth` + `claimedEth` in one go.
 - The token's `swapBack(uint256 amountOutMinWei)` external function is owner-only and produces the same event sequence as the auto-trigger only if the token has a non-zero owner. Factory-deployed V2 tokens are ownerless, so this manual path is inaccessible there.
 - Past the tax window (`block.timestamp > graduationTimestamp + taxDurationSeconds`), no tax transfer is taken and the `CreatorTaxSwapback` path is not entered.
 
@@ -240,6 +246,14 @@ The same event order applies to every successful non-zero deposit, regardless of
 
 Zero-value `depositFees(token)` (or `receive()` from a token) calls are no-ops and emit no fee events, including for unregistered tokens.
 
+### 9.1 Direct-handler tokens (no master-handler registration)
+
+V2 taxable tokens deployed with a single `directFeesEnabled = true` receiver via `LivoFactoryUniV2Unified` are NOT registered in the master fee handler — `token.feeHandler() == receiver` (the receiver address itself, possibly an EOA). On every fee accrual (`accrueFees` or the V2 auto-swap-back), the token's `_accrueFees` performs a plain ETH transfer to the receiver and NONE of the events listed in §9 fire. The only fee-related events for these tokens are:
+
+- **`LivoFactory.DirectSingleFeeReceiver`** (`token, receiver`) — emitted once, at token creation (see §1.1).
+- **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted on every swap-back (see §6.3 direct-handler variant).
+- **`LivoToken.FeeHandlerChanged`** — emitted when `setFeeHandler` rotates the receiver (see §12).
+
 ---
 
 ## 10. `LivoTaxableToken.setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps)`
@@ -267,3 +281,15 @@ Event order on a successful non-zero deposit:
 
 1. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token=msg.sender, amount`).
 2. For each direct receiver with a non-zero slice: optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, sliceAmount`) on a successful synchronous forward. A failed forward (including a recursive `receive()` blocked by the `nonReentrant` guard) silently records the slice as pending instead.
+
+---
+
+## 12. `LivoToken.setFeeHandler(address newFeeHandler)`
+
+Rotates the fee-handler address on the token. Callable by the current token `owner` OR by `launchpad.owner()`. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on those tokens only the launchpad-owner branch is reachable. Reverts on `newFeeHandler == address(0)` with `InvalidFeeHandler`.
+
+On success a single event is emitted:
+
+1. **`LivoToken.FeeHandlerChanged`** (`oldFeeHandler, newFeeHandler`).
+
+Primary use case: rotate the single direct receiver of a V2 taxable token deployed via the direct-handler path (§1.1 exception). The function does not gate by current state — admin can also redirect a master-routed token away from the master handler, which orphans the master handler's recipient set; existing pending claims there remain claimable but no new fees will arrive. Pointing back at the master handler when the token was never registered there will brick swap-backs (master handler's `_depositSingle` reverts on the unregistered config). Both are admin foot-guns.

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -286,10 +286,12 @@ Event order on a successful non-zero deposit:
 
 ## 12. `LivoToken.setFeeHandler(address newFeeHandler)`
 
-Rotates the fee-handler address on the token. Callable by the current token `owner` OR by `launchpad.owner()`. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on those tokens only the launchpad-owner branch is reachable. Reverts on `newFeeHandler == address(0)` with `InvalidFeeHandler`.
+Rotates the fee-handler address on the token. Callable by the current token `owner` OR by `launchpad.owner()`. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on those tokens only the launchpad-owner branch is reachable. Reverts on `newFeeHandler == address(0)` with `InvalidFeeHandler`, and on `current.code.length != 0 || newFeeHandler.code.length != 0` with `FeeHandlerMustBeEOA`.
+
+The EOA-on-both-sides gate makes the fee-handler effectively **immutable for master-routed tokens** (their current `feeHandler` is a contract, so the precondition fails) and restricts direct-handler tokens to rotating only among EOAs. Post-rotation, fees always flow directly to a wallet address, so master-handler events never fire for the token and the swap-back handler stays the sole accounting signal — the indexer's `TokenFeeData.isDirectFeeHandlerEOA` flag is trivially correct.
 
 On success a single event is emitted:
 
 1. **`LivoToken.FeeHandlerChanged`** (`oldFeeHandler, newFeeHandler`).
 
-Primary use case: rotate the single direct receiver of a V2 taxable token deployed via the direct-handler path (§1.1 exception). The function does not gate by current state — admin can also redirect a master-routed token away from the master handler, which orphans the master handler's recipient set; existing pending claims there remain claimable but no new fees will arrive. Pointing back at the master handler when the token was never registered there will brick swap-backs (master handler's `_depositSingle` reverts on the unregistered config). Both are admin foot-guns.
+Only use case: rotate the single direct receiver of a V2 taxable token deployed via the direct-handler path (§1.1 exception). Master-routed tokens cannot use this function at all.

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -44,7 +44,6 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 9. [Direct-fee behavior](#9-direct-fee-behavior)
 10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 11. [`LivoMasterFeeHandler.receive` (plain ETH)](#11-livomasterfeehandlerreceive-plain-eth)
-12. [`LivoToken.setFeeHandler`](#12-livotokensetfeehandleraddress-newfeehandler)
 
 ---
 
@@ -248,11 +247,10 @@ Zero-value `depositFees(token)` (or `receive()` from a token) calls are no-ops a
 
 ### 9.1 Direct-handler tokens (no master-handler registration)
 
-V2 taxable tokens deployed with a single `directFeesEnabled = true` receiver via `LivoFactoryUniV2Unified` are NOT registered in the master fee handler — `token.feeHandler() == receiver` (the receiver address itself, possibly an EOA). On every fee accrual (`accrueFees` or the V2 auto-swap-back), the token's `_accrueFees` performs a plain ETH transfer to the receiver and NONE of the events listed in §9 fire. The only fee-related events for these tokens are:
+V2 taxable tokens deployed with a single `directFeesEnabled = true` receiver via `LivoFactoryUniV2Unified` are NOT registered in the master fee handler — `token.feeHandler() == receiver` (the receiver address itself, possibly an EOA). On every fee accrual (`accrueFees` or the V2 auto-swap-back), the token's `_accrueFees` performs a plain ETH transfer to the receiver and NONE of the events listed in §9 fire. The receiver baked in at creation time is immutable for the life of the token. The only fee-related events for these tokens are:
 
 - **`LivoFactory.DirectSingleFeeReceiver`** (`token, receiver`) — emitted once, at token creation (see §1.1).
 - **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted on every swap-back (see §6.3 direct-handler variant).
-- **`LivoToken.FeeHandlerChanged`** — emitted when `setFeeHandler` rotates the receiver (see §12).
 
 ---
 
@@ -281,17 +279,3 @@ Event order on a successful non-zero deposit:
 
 1. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token=msg.sender, amount`).
 2. For each direct receiver with a non-zero slice: optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, sliceAmount`) on a successful synchronous forward. A failed forward (including a recursive `receive()` blocked by the `nonReentrant` guard) silently records the slice as pending instead.
-
----
-
-## 12. `LivoToken.setFeeHandler(address newFeeHandler)`
-
-Rotates the fee-handler address on the token. Callable by the current token `owner` OR by `launchpad.owner()`. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on those tokens only the launchpad-owner branch is reachable. Reverts on `newFeeHandler == address(0)` with `InvalidFeeHandler`, and on `current.code.length != 0 || newFeeHandler.code.length != 0` with `FeeHandlerMustBeEOA`.
-
-The EOA-on-both-sides gate makes the fee-handler effectively **immutable for master-routed tokens** (their current `feeHandler` is a contract, so the precondition fails) and restricts direct-handler tokens to rotating only among EOAs. Post-rotation, fees always flow directly to a wallet address, so master-handler events never fire for the token and the swap-back handler stays the sole accounting signal — the indexer's `TokenFeeData.isDirectFeeHandlerEOA` flag is trivially correct.
-
-On success a single event is emitted:
-
-1. **`LivoToken.FeeHandlerChanged`** (`oldFeeHandler, newFeeHandler`).
-
-Only use case: rotate the single direct receiver of a V2 taxable token deployed via the direct-handler path (§1.1 exception). Master-routed tokens cannot use this function at all.

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -44,7 +44,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 9. [Direct-fee behavior](#9-direct-fee-behavior)
 10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 11. [`LivoMasterFeeHandler.receive` (plain ETH)](#11-livomasterfeehandlerreceive-plain-eth)
-12. [`LivoToken.accrueFees` — `RouteFees`](#12-livotokenaccruefees--redirectfees)
+12. [`LivoToken._accrueFees` — `RouteFees`](#12-livotoken_accruefees--routefees)
 
 ---
 
@@ -284,10 +284,13 @@ Event order on a successful non-zero deposit:
 
 ---
 
-## 12. `LivoToken.accrueFees` — `RouteFees`
+## 12. `LivoToken._accrueFees` — `RouteFees`
 
-External `LivoToken.accrueFees()` emits **`LivoToken.RouteFees`** (`feeHandler, amount=msg.value`) before forwarding ETH to `feeHandler`. The event fires unconditionally on every call (including `msg.value == 0`) and is emitted regardless of whether the downstream ETH push to `feeHandler` succeeds — `_accrueFees` swallows transfer failures (see contract NatSpec).
+Every fee push to `feeHandler` that goes through `LivoToken._accrueFees` (the shared internal helper) emits **`LivoToken.RouteFees`** (`feeHandler, amount`) immediately before the ETH `call`. Zero-value calls return early and emit nothing. The event is emitted regardless of whether the downstream ETH push succeeds — `_accrueFees` swallows transfer failures (see contract NatSpec).
 
-Callers that route through `LivoToken.accrueFees()` include the graduators (`CreatorGraduationFeeCollected` paths in §§3–4) and `LivoSwapHook` (§§6.1–6.2). The V2 in-token swap-back path (§6.3) bypasses the external entry point and calls `_accrueFees` directly, so it does NOT emit `RouteFees`.
+All paths that route fees to `feeHandler` go through this helper, so `RouteFees` fires on:
+
+- External `LivoToken.accrueFees()` calls — used by the graduators (`CreatorGraduationFeeCollected` paths in §§3–4) and `LivoSwapHook` (§§6.1–6.2).
+- The V2 taxable in-token swap-back path (§6.3), which calls `_accrueFees` directly with the contract's ETH balance after the swap.
 
 The indexer does not currently consume `RouteFees`; downstream accounting still relies on `LivoMasterFeeHandler.CreatorFeesDeposited` / `CreatorClaimed` (or the direct-handler signals in §9.1).

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -40,6 +40,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 7. [`LivoMasterFeeHandler.claim`](#7-livomasterfeehandlerclaimaddress-tokens)
 8. [`LivoMasterFeeHandler.setShares`](#8-livomasterfeehandlersetsharesaddress-token-feeshare-feeshares)
 9. [Direct-fee behavior](#9-direct-fee-behavior)
+10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 
 ---
 
@@ -237,3 +238,15 @@ For every successful non-zero `depositFees(token)` against a registered config:
 3. Claimable recipients do not emit per-deposit claim events; they accrue through the master handler accumulator and emit `CreatorClaimed` only when they call `claim()`.
 
 Zero-value `depositFees(token)` calls are no-ops and emit no fee events, including for unregistered tokens.
+
+---
+
+## 10. `LivoTaxableToken.setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps)`
+
+Owner-only entry point on both `LivoTaxableTokenUniV2` (and its sniper-protected variant) and `LivoTaxableTokenUniV4` (and its sniper-protected variant). Callable by the token owner OR `launchpad.owner()` — on factory-deployed tokens (`owner == address(0)`) only the launchpad-owner branch is reachable.
+
+The function is decrease-only: `newBuyTaxBps` and `newSellTaxBps` must both be `<= ` their current values, otherwise the call reverts with `TaxBpsCanOnlyDecrease`. Equal values are accepted (no-op for that side). `taxDurationSeconds` and `graduationTimestamp` are untouched.
+
+On success:
+
+1. **`LivoTaxableToken.TaxBpsUpdated`** (`newBuyTaxBps, newSellTaxBps`) — emitted before the storage write. Old values can be reconstructed from the preceding `LivoTaxableTokenInitialized` event at creation time and the chain of any prior `TaxBpsUpdated` events.

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -44,6 +44,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 9. [Direct-fee behavior](#9-direct-fee-behavior)
 10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 11. [`LivoMasterFeeHandler.receive` (plain ETH)](#11-livomasterfeehandlerreceive-plain-eth)
+12. [`LivoToken.accrueFees` — `RouteFees`](#12-livotokenaccruefees--redirectfees)
 
 ---
 
@@ -197,7 +198,7 @@ Indexer-relevant points:
   4. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token, amount=ethAmount`) emitted by the handler's `receive()` (attribution via `msg.sender = token`).
   5. Optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, amount`) for each successful direct forward.
 
-  **Direct-handler variant (V2 taxable + single direct receiver).** When the token was deployed on the direct-handler path (see §1.1), `token.feeHandler` is the receiver itself and the swap-back's plain ETH transfer never reaches the master handler. Only steps 1–3 above happen on-chain — `LivoMasterFeeHandler.CreatorFeesDeposited` and `CreatorClaimed` are NOT emitted in this variant. The indexer relies solely on `CreatorTaxSwapback` (paired with the `TokenFeeData.isDirectFeeHandlerEOA` flag set at deploy) to advance `accountedEth` + `accruedEth` + `claimedEth` in one go.
+  **Direct-handler variant (V2 taxable + single direct receiver).** When the token was deployed on the direct-handler path (see §1.1), `token.feeHandler` is the receiver itself and the swap-back's plain ETH transfer never reaches the master handler. Only steps 1–3 above happen on-chain — `LivoMasterFeeHandler.CreatorFeesDeposited` and `CreatorClaimed` are NOT emitted in this variant. The indexer relies solely on `CreatorTaxSwapback` (paired with the `TokenFeeData.directFeeHandlerIsNotMasterFeeHandler` flag set at deploy) to advance `accountedEth` + `accruedEth` + `claimedEth` in one go.
 - The token's `swapBack(uint256 amountOutMinWei)` external function is owner-only and produces the same event sequence as the auto-trigger only if the token has a non-zero owner. Factory-deployed V2 tokens are ownerless, so this manual path is inaccessible there.
 - Past the tax window (`block.timestamp > graduationTimestamp + taxDurationSeconds`), no tax transfer is taken and the `CreatorTaxSwapback` path is not entered.
 
@@ -251,6 +252,7 @@ V2 taxable tokens deployed with a single `directFeesEnabled = true` receiver via
 
 - **`LivoFactory.DirectSingleFeeReceiver`** (`token, receiver`) — emitted once, at token creation (see §1.1).
 - **`LivoTaxableTokenUniV2.CreatorTaxSwapback`** (`tokenAmountIn, ethAmount`) — emitted on every swap-back (see §6.3 direct-handler variant).
+- **`LivoGraduator.CreatorGraduationFeeCollected`** (`token, amount`) — emitted by the graduator just before its `accrueFees()` push to the token at graduation time. The indexer treats this as the direct-handler bookkeeping signal for the graduation fee on these tokens (master-routed tokens get the equivalent accounting via the master handler's downstream `CreatorFeesDeposited` / `CreatorClaimed`).
 
 ---
 
@@ -279,3 +281,13 @@ Event order on a successful non-zero deposit:
 
 1. **`LivoMasterFeeHandler.CreatorFeesDeposited`** (`token=msg.sender, amount`).
 2. For each direct receiver with a non-zero slice: optional **`LivoMasterFeeHandler.CreatorClaimed`** (`token, directReceiver, sliceAmount`) on a successful synchronous forward. A failed forward (including a recursive `receive()` blocked by the `nonReentrant` guard) silently records the slice as pending instead.
+
+---
+
+## 12. `LivoToken.accrueFees` — `RouteFees`
+
+External `LivoToken.accrueFees()` emits **`LivoToken.RouteFees`** (`feeHandler, amount=msg.value`) before forwarding ETH to `feeHandler`. The event fires unconditionally on every call (including `msg.value == 0`) and is emitted regardless of whether the downstream ETH push to `feeHandler` succeeds — `_accrueFees` swallows transfer failures (see contract NatSpec).
+
+Callers that route through `LivoToken.accrueFees()` include the graduators (`CreatorGraduationFeeCollected` paths in §§3–4) and `LivoSwapHook` (§§6.1–6.2). The V2 in-token swap-back path (§6.3) bypasses the external entry point and calls `_accrueFees` directly, so it does NOT emit `RouteFees`.
+
+The indexer does not currently consume `RouteFees`; downstream accounting still relies on `LivoMasterFeeHandler.CreatorFeesDeposited` / `CreatorClaimed` (or the direct-handler signals in §9.1).

--- a/justfile
+++ b/justfile
@@ -53,13 +53,27 @@ error-inspection errorhex:
 taxtokenaddresses:
     sed -i 's#import {DeploymentAddressesMainnet as DeploymentAddresses} from "src/config/DeploymentAddresses.sol";#import {DeploymentAddressesSepolia as DeploymentAddresses} from "src/config/DeploymentAddresses.sol";#' src/tokens/LivoTaxableTokenUniV2.sol src/tokens/LivoTaxableTokenUniV4.sol
 
-# Prints a valid salt (produces a token address ending in 0x1110) for the given factory.
-# Usage: just next-salt <factoryAddress>
-next-salt factory:
+# Prints a valid salt (produces a token address ending in 0x1110) for the given factory + impl getter.
+# Unified factories expose multiple impl getters (TOKEN_IMPL_BASE, TOKEN_IMPL_TAX, ...); pass the one
+# matching the variant being deployed so the create2 initcode hash is correct.
+# Usage: just next-salt <factoryAddress> <implGetterName>
+next-salt factory implFn:
     #!/usr/bin/env bash
     set -euo pipefail
-    IMPL=$(cast call --rpc-url $SEPOLIA_RPC_URL {{factory}} "TOKEN_IMPLEMENTATION()(address)")
+    IMPL=$(cast call --rpc-url $SEPOLIA_RPC_URL {{factory}} "{{implFn}}()(address)")
     INIT_CODE="0x3d602d80600a3d3981f3363d3d373d3d3d363d73${IMPL:2}5af43d82803e903d91602b57fd5bf3"
+    cast create2 --ends-with 1110 --deployer {{factory}} --init-code "$INIT_CODE" \
+        | awk '/^Salt:/ {print $2}'
+
+# Same as next-salt but skips the factory getter lookup — pass the impl address directly.
+# Useful when the factory does not expose the getter you need, or when you already know the impl.
+# Usage: just next-salt-impl <factoryAddress> <implAddress>
+next-salt-impl factory impl:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    IMPL="{{impl}}"
+    IMPL="${IMPL#0x}"
+    INIT_CODE="0x3d602d80600a3d3981f3363d3d373d3d3d363d73${IMPL}5af43d82803e903d91602b57fd5bf3"
     cast create2 --ends-with 1110 --deployer {{factory}} --init-code "$INIT_CODE" \
         | awk '/^Salt:/ {print $2}'
 
@@ -70,33 +84,26 @@ bondingCurve := "0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5"
 graduatorV2 := "0x1c10331F153cD344Feb030Aad7A11E2119F6f59A"
 graduatorV4 := "0xc304593F9297f4f67E07cc7cAf3128F9027A2A3d"
 
-factoryV2 := "0x2E8325243b87fB78711092D13538cB4CDbf3d098"
-factoryV4 := "0xE6A46F0c681F7F67b349C77Ff2329dB4F016691E"
-factoryTaxToken := "0x124972595Af23c2FbEE4b77a24ceF8d6af800016"
-factoryExtendedTax := "0x2Ac66442930112836152D426d95634c274cF2aaf"
-# Sniper-protected factories — fill in after deploy.
-factorySniperProtected := "0x0000000000000000000000000000000000000000"
-factoryV2SniperProtected := "0x0000000000000000000000000000000000000000"
-factoryTaxTokenSniperProtected := "0x0000000000000000000000000000000000000000"
+# Unified factories — each dispatches between base / tax / sniper-protected / tax+sniper impls
+# based on the configs passed to createToken. See deployments.sepolia.sol for the source of truth.
+factoryV2 := "0x87Dd69F8d294fA9cd704fccd38d36d6197F80868"
+factoryV4 := "0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b"
 hookAddress := "0x0591a87D3a56797812C4DA164C1B005c545400Cc"
 
 livodev := "0xBa489180Ea6EEB25cA65f123a46F3115F388f181"
 
 # ##################### Create tokens #######################
 #
-# All factory `createToken` signatures take:
-#   (string name, string symbol, bytes32 salt, FeeShare[] feeReceivers, SupplyShare[] supplyShares, ...)
-# with optional trailing `TaxConfigInit` and/or `AntiSniperConfigs` tuples.
+# Unified factory `createToken` signatures:
+#   V2: (string,string,bytes32,FeeShare[],SupplyShare[],TaxConfigInit,AntiSniperConfigs)
+#   V4: (string,string,bytes32,FeeShare[],SupplyShare[],bool renounceOwnership_,TaxConfigInit,AntiSniperConfigs)
 #
 # Canonical ABI tuples:
-#   FeeShare           = (address,uint256)       — shares in bps, must sum to 10_000
-#   SupplyShare        = (address,uint256)       — shares in bps, must sum to 10_000 (empty when no deployer buy)
-#   TaxConfigInit      = (uint16,uint16,uint32)  — buyTaxBps, sellTaxBps, taxDurationSeconds
-#   AntiSniperConfigs  = (uint16,uint16,uint40,address[])  — maxBuyPerTxBps, maxWalletBps, windowSeconds, whitelist
+#   FeeShare           = (address,uint256,bool)            — account, sharesBps, directFeesEnabled (sum bps == 10_000)
+#   SupplyShare        = (address,uint256)                 — account, sharesBps (empty when no deployer buy)
+#   TaxConfigInit      = (uint16,uint16,uint32)            — buyTaxBps, sellTaxBps, taxDurationSeconds  ((0,0,0) disables)
+#   AntiSniperConfigs  = (uint16,uint16,uint40,address[])  — maxBuyPerTxBps, maxWalletBps, protectionWindowSeconds, whitelist  ((0,0,0,[]) disables)
 #
-# Fee-split shareholders used by the `*-feesplit` recipes:
-#   sharehonlder1 = 0x26fFa73c8fFcB8F4BF55d5A11a57c6bfEA7F4495
-#   sharehonlder2 = 0x643e37aCbbbc8e6e2b548C3eA150fDf9BAB8C27f
 # Test wallets:
 #   tiswallet1 = 0xd6fa895fABA3FE48410e9A00504BB556C89dd2E6
 #   tiswallet2 = 0xdbB91f98C5826C89CC2312AD0B5a377a77613884
@@ -127,90 +134,41 @@ deploy-swap-hook-mainnet:
 export-deployments:
     forge script ExportDeployments
 
-create-token-v2 tokenName value="0":
-    SALT=$(just next-salt {{factoryV2}}) && echo "Using salt: $SALT" && \
+# Plain V2 token: no tax, no sniper protection. Single fee receiver (livodev), no deployer buy.
+univ2 tokenName value="0":
+    SALT=$(just next-salt {{factoryV2}} TOKEN_IMPL_BASE) && echo "Using salt: $SALT" && \
         cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV2}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[])" \
+            "createToken(string,string,bytes32,(address,uint256,bool)[],(address,uint256)[],(uint16,uint16,uint32),(uint16,uint16,uint40,address[]))" \
             {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" --value {{value}}
+            "[({{livodev}},10000,false)]" "[]" \
+            "(0,0,0)" "(0,0,0,[])" --value {{value}}
 
-create-token-v4 tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryV4}}) && echo "Using salt: $SALT" && \
+# Plain V4 token: no tax, no sniper protection. Single fee receiver (livodev), no deployer buy. Ownership retained.
+univ4 tokenName value="0":
+    SALT=$(just next-salt {{factoryV4}} TOKEN_IMPL_BASE) && echo "Using salt: $SALT" && \
         cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV4}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool)" \
+            "createToken(string,string,bytes32,(address,uint256,bool)[],(address,uint256)[],bool,(uint16,uint16,uint32),(uint16,uint16,uint40,address[]))" \
             {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" {{renounceOwnership}} --value {{value}}
+            "[({{livodev}},10000,false)]" "[]" false \
+            "(0,0,0)" "(0,0,0,[])" --value {{value}}
 
-create-tax-token tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryTaxToken}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryTaxToken}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint32))" \
+# Taxable V2 token: tax enabled (buy=300, sell=500, duration=1209600 = 2 weeks), no sniper protection.
+univ2-taxable tokenName value="0":
+    SALT=$(just next-salt {{factoryV2}} TOKEN_IMPL_TAX) && echo "Using salt: $SALT" && \
+        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV2}} \
+            "createToken(string,string,bytes32,(address,uint256,bool)[],(address,uint256)[],(uint16,uint16,uint32),(uint16,uint16,uint40,address[]))" \
             {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" {{renounceOwnership}} \
-            "(300,500,1209600)" --value {{value}}
+            "[({{livodev}},10000,false)]" "[]" \
+            "(300,500,1209600)" "(0,0,0,[])" --value {{value}}
 
-create-token-v4-feesplit tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryV4}}) && echo "Using salt: $SALT" && \
+# Taxable V4 token: tax enabled (buy=300, sell=500, duration=1209600 = 2 weeks), no sniper protection. Ownership retained.
+univ4-taxable tokenName value="0":
+    SALT=$(just next-salt {{factoryV4}} TOKEN_IMPL_TAX) && echo "Using salt: $SALT" && \
         cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV4}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool)" \
+            "createToken(string,string,bytes32,(address,uint256,bool)[],(address,uint256)[],bool,(uint16,uint16,uint32),(uint16,uint16,uint40,address[]))" \
             {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[(0x26fFa73c8fFcB8F4BF55d5A11a57c6bfEA7F4495,3000),(0x643e37aCbbbc8e6e2b548C3eA150fDf9BAB8C27f,7000)]" \
-            "[]" {{renounceOwnership}} --value {{value}}
-
-create-tax-token-feesplit tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryTaxToken}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryTaxToken}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint32))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[(0x26fFa73c8fFcB8F4BF55d5A11a57c6bfEA7F4495,3000),(0x643e37aCbbbc8e6e2b548C3eA150fDf9BAB8C27f,7000)]" \
-            "[]" {{renounceOwnership}} \
-            "(300,500,1209600)" --value {{value}}
-
-# ExtendedTax factory: owner-only, 10% tax cap, no duration cap. Defaults shown: buy=800, sell=1000, duration=365 days.
-create-extended-tax-token tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryExtendedTax}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryExtendedTax}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint32))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" {{renounceOwnership}} \
-            "(800,1000,31536000)" --value {{value}}
-
-create-extended-tax-token-feesplit tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryExtendedTax}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryExtendedTax}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint32))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[(0x26fFa73c8fFcB8F4BF55d5A11a57c6bfEA7F4495,3000),(0x643e37aCbbbc8e6e2b548C3eA150fDf9BAB8C27f,7000)]" \
-            "[]" {{renounceOwnership}} \
-            "(800,1000,31536000)" --value {{value}}
-
-# ##################### Create tokens — sniper-protected variants #######################
-# Default AntiSniperConfigs: 3% max buy, 3% max wallet, 3h window, empty whitelist.
-
-create-token-v2-sniper tokenName value="0":
-    SALT=$(just next-salt {{factoryV2SniperProtected}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV2SniperProtected}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],(uint16,uint16,uint40,address[]))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" \
-            "(300,300,10800,[])" --value {{value}}
-
-create-token-v4-sniper tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factorySniperProtected}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factorySniperProtected}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint40,address[]))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" {{renounceOwnership}} \
-            "(300,300,10800,[])" --value {{value}}
-
-create-tax-token-sniper tokenName value="0" renounceOwnership="false":
-    SALT=$(just next-salt {{factoryTaxTokenSniperProtected}}) && echo "Using salt: $SALT" && \
-        cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryTaxTokenSniperProtected}} \
-            "createToken(string,string,bytes32,(address,uint256)[],(address,uint256)[],bool,(uint16,uint16,uint32),(uint16,uint16,uint40,address[]))" \
-            {{tokenName}} {{uppercase(tokenName)}} "$SALT" \
-            "[({{livodev}},10000)]" "[]" {{renounceOwnership}} \
-            "(300,500,1209600)" \
-            "(300,300,10800,[])" --value {{value}}
+            "[({{livodev}},10000,false)]" "[]" false \
+            "(300,500,1209600)" "(0,0,0,[])" --value {{value}}
 
 ####################### Buys / sells #################################
 

--- a/justfile
+++ b/justfile
@@ -20,7 +20,6 @@ abis:
     @jq '.abi' out/ILivoClaims.sol/ILivoClaims.json > abis/ILivoClaims.json
     @jq '.abi' out/LivoFactoryUniV2Unified.sol/LivoFactoryUniV2Unified.json > abis/LivoFactoryUniV2Unified.json
     @jq '.abi' out/LivoFactoryUniV4Unified.sol/LivoFactoryUniV4Unified.json > abis/LivoFactoryUniV4Unified.json
-    @jq '.abi' out/ILivoFeeSplitter.sol/ILivoFeeSplitter.json > abis/ILivoFeeSplitter.json
     @jq '.abi' out/ILivoTaxableToken.sol/ILivoTaxableToken.json > abis/ILivoTaxableToken.json
     @echo "✔ ABIs copied to abis/ directory"
     

--- a/script/RedeployAllImpls.s.sol
+++ b/script/RedeployAllImpls.s.sol
@@ -11,7 +11,6 @@ import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
 import {LivoTaxableTokenUniV4SniperProtected} from "src/tokens/LivoTaxableTokenUniV4SniperProtected.sol";
 import {LivoFactoryUniV2Unified} from "src/factories/LivoFactoryUniV2Unified.sol";
 import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
-import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 
 import {DeploymentAddresses as AddressesFromLivoTaxableTokenV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
 import {DeploymentAddresses as AddressesFromLivoTaxableTokenV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
@@ -20,7 +19,7 @@ import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config
 import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
 import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
 
-/// @title Redeploy ALL token implementations + upgrade BOTH unified factories to the new master fee handler
+/// @title Redeploy ALL token implementations + both unified factory implementations
 /// @notice Wraps up the rollout for the `receive()` refactor on `LivoMasterFeeHandler` and the
 ///         matching `_accrueFees` migration on every token (base / sniper-protected / V2 tax /
 ///         V4 tax). Existing deployed tokens keep pointing at the OLD master fee handler — they
@@ -30,7 +29,7 @@ import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
 ///
 ///         Pre-requisite (manual step, done OFF this script): deploy the new `LivoMasterFeeHandler`
 ///         and write its address into `MASTER_FEE_HANDLER` in `src/config/deployments.<chain>.sol`.
-///         This script reads that constant and refuses to run if it still matches the old handler.
+///         This script reads that constant and refuses to run if it's missing or has no code.
 ///
 ///         Single broadcast:
 ///         1. Deploy fresh `LivoToken` (non-tax base).
@@ -43,34 +42,26 @@ import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
 ///            `MASTER_FEE_HANDLER` + V2 token impls + the unchanged V2 graduator / bonding curve / launchpad.
 ///         8. Deploy fresh `LivoFactoryUniV4Unified` impl, wired to the manifest's
 ///            `MASTER_FEE_HANDLER` + V4 token impls + the unchanged V4 graduator / bonding curve / launchpad.
-///         9. `upgradeToAndCall(newV2FactoryImpl, "")` on the existing V2 proxy.
-///        10. `upgradeToAndCall(newV4FactoryImpl, "")` on the existing V4 proxy.
 ///
-///         Proxy addresses are UNCHANGED — launchpad's `whitelistedFactories` entries stay valid;
-///         integrators see no address change. No init data is passed; no new factory storage was
-///         added.
-///
-///         The broadcaster MUST be the proxy owner on BOTH proxies. If not, `_authorizeUpgrade`
-///         reverts with `OwnableUnauthorizedAccount(broadcaster)` and the whole script reverts.
+///         The factory proxy upgrades are intentionally NOT performed here — they are a separate,
+///         manual follow-up step done after the new impls have been deployed and inspected.
 ///
 ///         Pre-broadcast sanity: confirms both V2 and V4 tax-token sources import the right
 ///         per-chain `DeploymentAddresses`. Run `just taxtokenaddresses` before deploying to Sepolia.
 ///
 ///         Post-broadcast: update all six token impl addresses and both
 ///         `FACTORY_UNI*_UNIFIED_IMPL` addresses in `src/config/deployments.<chain>.sol`, then run
-///         `just export-deployments`.
+///         `just export-deployments`. The proxy upgrades (`upgradeToAndCall` on each unified factory
+///         proxy) are run separately once the new impls are verified.
 ///
 /// @dev    Run with:
-///         forge script RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler --rpc-url <mainnet|sepolia> \
+///         forge script RedeployAllImpls --rpc-url <mainnet|sepolia> \
 ///             --verify --account livo.dev --slow --broadcast
-contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
-    /// @dev Per-chain addresses needed to wire the new factory implementations and target the
-    ///      proxy upgrades. Pulled from `src/config/deployments.<chain>.sol`. `masterFeeHandler`
-    ///      must already point at the freshly-deployed handler (manual pre-step).
+contract RedeployAllImpls is Script {
+    /// @dev Per-chain addresses needed to wire the new factory implementations. Pulled from
+    ///      `src/config/deployments.<chain>.sol`. `masterFeeHandler` must already point at the
+    ///      freshly-deployed handler (manual pre-step).
     struct Deps {
-        // Proxies to upgrade
-        address factoryV2Proxy;
-        address factoryV4Proxy;
         // Shared inputs reused by both fresh factory impls (unchanged across this redeploy)
         address launchpad;
         address bondingCurve;
@@ -95,8 +86,6 @@ contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
     function _getDeps() internal view returns (Deps memory d) {
         if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
             d = Deps({
-                factoryV2Proxy: DeploymentsMainnet.FACTORY_UNIV2_UNIFIED,
-                factoryV4Proxy: DeploymentsMainnet.FACTORY_UNIV4_UNIFIED,
                 launchpad: DeploymentsMainnet.LAUNCHPAD,
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
@@ -113,8 +102,6 @@ contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
             );
         } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
             d = Deps({
-                factoryV2Proxy: DeploymentsSepolia.FACTORY_UNIV2_UNIFIED,
-                factoryV4Proxy: DeploymentsSepolia.FACTORY_UNIV4_UNIFIED,
                 launchpad: DeploymentsSepolia.LAUNCHPAD,
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
@@ -133,8 +120,6 @@ contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
             revert("Unsupported chain");
         }
 
-        require(d.factoryV2Proxy != address(0), "manifest: FACTORY_UNIV2_UNIFIED missing");
-        require(d.factoryV4Proxy != address(0), "manifest: FACTORY_UNIV4_UNIFIED missing");
         require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
@@ -147,19 +132,9 @@ contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
         Deps memory d = _getDeps();
         FreshDeployments memory fresh;
 
-        // Catch wrong manifest addresses pointing at non-Livo contracts before we waste deploys.
-        address v2ProxyOwner = LivoFactoryUniV2Unified(d.factoryV2Proxy).owner();
-        address v4ProxyOwner = LivoFactoryUniV4Unified(d.factoryV4Proxy).owner();
-        require(v2ProxyOwner != address(0), "V2 proxy not initialized");
-        require(v4ProxyOwner != address(0), "V4 proxy not initialized");
-        require(v2ProxyOwner == v4ProxyOwner, "V2 and V4 proxy owners differ; review before upgrading");
-
-        console.log("=== Livo All-Impls Redeploy + Both Factory Upgrades (new MasterFeeHandler) ===");
+        console.log("=== Livo All-Impls Redeploy (new MasterFeeHandler) ===");
         console.log("Chain ID:                ", block.chainid);
         console.log("Broadcaster:             ", msg.sender);
-        console.log("Required proxy owner:    ", v2ProxyOwner);
-        console.log("V2 factory proxy:        ", d.factoryV2Proxy);
-        console.log("V4 factory proxy:        ", d.factoryV4Proxy);
         console.log("MASTER_FEE_HANDLER (from manifest):", d.masterFeeHandler);
         console.log("");
 
@@ -217,19 +192,11 @@ contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
         );
         console.log("| LivoFactoryUniV4Unified (new impl)            |", fresh.factoryV4Impl);
 
-        // --- (9-10) Proxy upgrades ---
-        UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
-        console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
-
-        UUPSUpgradeable(d.factoryV4Proxy).upgradeToAndCall(fresh.factoryV4Impl, "");
-        console.log("| V4 proxy upgraded to                          |", fresh.factoryV4Impl);
-
         vm.stopBroadcast();
 
         console.log("");
         console.log("=== Redeploy Complete ===");
-        console.log("Proxy addresses are UNCHANGED - no launchpad whitelisting or integrator action needed.");
-        console.log("Existing deployed tokens keep pointing at the OLD master fee handler.");
+        console.log("Factory proxies were NOT upgraded - run the proxy upgrade step manually next.");
         console.log("Update the per-chain manifest with these addresses, then run `just export-deployments`:");
         console.log("  TOKEN_IMPL                             :", fresh.tokenImpl);
         console.log("  TOKEN_SNIPER_PROTECTED_IMPL            :", fresh.tokenSniperImpl);

--- a/script/RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler.s.sol
+++ b/script/RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler.s.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {LivoToken} from "src/tokens/LivoToken.sol";
+import {LivoTokenSniperProtected} from "src/tokens/LivoTokenSniperProtected.sol";
+import {LivoTaxableTokenUniV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {LivoTaxableTokenUniV2SniperProtected} from "src/tokens/LivoTaxableTokenUniV2SniperProtected.sol";
+import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+import {LivoTaxableTokenUniV4SniperProtected} from "src/tokens/LivoTaxableTokenUniV4SniperProtected.sol";
+import {LivoFactoryUniV2Unified} from "src/factories/LivoFactoryUniV2Unified.sol";
+import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
+import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @title Redeploy ALL token implementations + upgrade BOTH unified factories to the new master fee handler
+/// @notice Wraps up the rollout for the `receive()` refactor on `LivoMasterFeeHandler` and the
+///         matching `_accrueFees` migration on every token (base / sniper-protected / V2 tax /
+///         V4 tax). Existing deployed tokens keep pointing at the OLD master fee handler — they
+///         still use the legacy `depositFees(address(this))` path, which works unchanged. New
+///         tokens spun up by the upgraded factories will use the NEW master fee handler via the
+///         direct-ETH-transfer / `receive()` entry point.
+///
+///         Pre-requisite (manual step, done OFF this script): deploy the new `LivoMasterFeeHandler`
+///         and write its address into `MASTER_FEE_HANDLER` in `src/config/deployments.<chain>.sol`.
+///         This script reads that constant and refuses to run if it still matches the old handler.
+///
+///         Single broadcast:
+///         1. Deploy fresh `LivoToken` (non-tax base).
+///         2. Deploy fresh `LivoTokenSniperProtected` (non-tax + sniper).
+///         3. Deploy fresh `LivoTaxableTokenUniV2`.
+///         4. Deploy fresh `LivoTaxableTokenUniV2SniperProtected`.
+///         5. Deploy fresh `LivoTaxableTokenUniV4`.
+///         6. Deploy fresh `LivoTaxableTokenUniV4SniperProtected`.
+///         7. Deploy fresh `LivoFactoryUniV2Unified` impl, wired to the manifest's
+///            `MASTER_FEE_HANDLER` + V2 token impls + the unchanged V2 graduator / bonding curve / launchpad.
+///         8. Deploy fresh `LivoFactoryUniV4Unified` impl, wired to the manifest's
+///            `MASTER_FEE_HANDLER` + V4 token impls + the unchanged V4 graduator / bonding curve / launchpad.
+///         9. `upgradeToAndCall(newV2FactoryImpl, "")` on the existing V2 proxy.
+///        10. `upgradeToAndCall(newV4FactoryImpl, "")` on the existing V4 proxy.
+///
+///         Proxy addresses are UNCHANGED — launchpad's `whitelistedFactories` entries stay valid;
+///         integrators see no address change. No init data is passed; no new factory storage was
+///         added.
+///
+///         The broadcaster MUST be the proxy owner on BOTH proxies. If not, `_authorizeUpgrade`
+///         reverts with `OwnableUnauthorizedAccount(broadcaster)` and the whole script reverts.
+///
+///         Pre-broadcast sanity: confirms both V2 and V4 tax-token sources import the right
+///         per-chain `DeploymentAddresses`. Run `just taxtokenaddresses` before deploying to Sepolia.
+///
+///         Post-broadcast: update all six token impl addresses and both
+///         `FACTORY_UNI*_UNIFIED_IMPL` addresses in `src/config/deployments.<chain>.sol`, then run
+///         `just export-deployments`.
+///
+/// @dev    Run with:
+///         forge script RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler --rpc-url <mainnet|sepolia> \
+///             --verify --account livo.dev --slow --broadcast
+contract RedeployAllImplsAndUpgradeFactoriesToNewFeeHandler is Script {
+    /// @dev Per-chain addresses needed to wire the new factory implementations and target the
+    ///      proxy upgrades. Pulled from `src/config/deployments.<chain>.sol`. `masterFeeHandler`
+    ///      must already point at the freshly-deployed handler (manual pre-step).
+    struct Deps {
+        // Proxies to upgrade
+        address factoryV2Proxy;
+        address factoryV4Proxy;
+        // Shared inputs reused by both fresh factory impls (unchanged across this redeploy)
+        address launchpad;
+        address bondingCurve;
+        address graduatorV2;
+        address graduatorV4;
+        // New master fee handler — deployed manually beforehand and stamped into the manifest
+        address masterFeeHandler;
+    }
+
+    /// @dev Addresses emitted by this script (for logging + manifest updates).
+    struct FreshDeployments {
+        address tokenImpl;
+        address tokenSniperImpl;
+        address taxTokenV2Impl;
+        address taxTokenV2SniperImpl;
+        address taxTokenV4Impl;
+        address taxTokenV4SniperImpl;
+        address factoryV2Impl;
+        address factoryV4Impl;
+    }
+
+    function _getDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsMainnet.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsMainnet.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                bondingCurve: DeploymentsMainnet.BONDING_CURVE,
+                graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+        } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsSepolia.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsSepolia.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                bondingCurve: DeploymentsSepolia.BONDING_CURVE,
+                graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+        } else {
+            revert("Unsupported chain");
+        }
+
+        require(d.factoryV2Proxy != address(0), "manifest: FACTORY_UNIV2_UNIFIED missing");
+        require(d.factoryV4Proxy != address(0), "manifest: FACTORY_UNIV4_UNIFIED missing");
+        require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
+        require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
+        require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
+        require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
+        require(d.masterFeeHandler.code.length > 0, "manifest: MASTER_FEE_HANDLER has no code at this address");
+    }
+
+    function run() public {
+        Deps memory d = _getDeps();
+        FreshDeployments memory fresh;
+
+        // Catch wrong manifest addresses pointing at non-Livo contracts before we waste deploys.
+        address v2ProxyOwner = LivoFactoryUniV2Unified(d.factoryV2Proxy).owner();
+        address v4ProxyOwner = LivoFactoryUniV4Unified(d.factoryV4Proxy).owner();
+        require(v2ProxyOwner != address(0), "V2 proxy not initialized");
+        require(v4ProxyOwner != address(0), "V4 proxy not initialized");
+        require(v2ProxyOwner == v4ProxyOwner, "V2 and V4 proxy owners differ; review before upgrading");
+
+        console.log("=== Livo All-Impls Redeploy + Both Factory Upgrades (new MasterFeeHandler) ===");
+        console.log("Chain ID:                ", block.chainid);
+        console.log("Broadcaster:             ", msg.sender);
+        console.log("Required proxy owner:    ", v2ProxyOwner);
+        console.log("V2 factory proxy:        ", d.factoryV2Proxy);
+        console.log("V4 factory proxy:        ", d.factoryV4Proxy);
+        console.log("MASTER_FEE_HANDLER (from manifest):", d.masterFeeHandler);
+        console.log("");
+
+        vm.startBroadcast();
+
+        console.log("| Contract Name                                  | Address |");
+        console.log("| ---------------------------------------------- | --- |");
+
+        // --- (1-2) Non-tax token implementations ---
+        fresh.tokenImpl = address(new LivoToken());
+        console.log("| LivoToken (new impl)                          |", fresh.tokenImpl);
+
+        fresh.tokenSniperImpl = address(new LivoTokenSniperProtected());
+        console.log("| LivoTokenSniperProtected (new impl)           |", fresh.tokenSniperImpl);
+
+        // --- (3-6) Tax-token implementations ---
+        fresh.taxTokenV2Impl = address(new LivoTaxableTokenUniV2());
+        console.log("| LivoTaxableTokenUniV2 (new impl)              |", fresh.taxTokenV2Impl);
+
+        fresh.taxTokenV2SniperImpl = address(new LivoTaxableTokenUniV2SniperProtected());
+        console.log("| LivoTaxableTokenUniV2SniperProtected (new)    |", fresh.taxTokenV2SniperImpl);
+
+        fresh.taxTokenV4Impl = address(new LivoTaxableTokenUniV4());
+        console.log("| LivoTaxableTokenUniV4 (new impl)              |", fresh.taxTokenV4Impl);
+
+        fresh.taxTokenV4SniperImpl = address(new LivoTaxableTokenUniV4SniperProtected());
+        console.log("| LivoTaxableTokenUniV4SniperProtected (new)    |", fresh.taxTokenV4SniperImpl);
+
+        // --- (7-8) Factory implementations wired to the manifest's master fee handler + fresh token impls ---
+        fresh.factoryV2Impl = address(
+            new LivoFactoryUniV2Unified(
+                d.launchpad,
+                fresh.tokenImpl,
+                fresh.tokenSniperImpl,
+                fresh.taxTokenV2Impl,
+                fresh.taxTokenV2SniperImpl,
+                d.bondingCurve,
+                d.graduatorV2,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV2Unified (new impl)            |", fresh.factoryV2Impl);
+
+        fresh.factoryV4Impl = address(
+            new LivoFactoryUniV4Unified(
+                d.launchpad,
+                fresh.tokenImpl,
+                fresh.tokenSniperImpl,
+                fresh.taxTokenV4Impl,
+                fresh.taxTokenV4SniperImpl,
+                d.bondingCurve,
+                d.graduatorV4,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV4Unified (new impl)            |", fresh.factoryV4Impl);
+
+        // --- (9-10) Proxy upgrades ---
+        UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
+        console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
+
+        UUPSUpgradeable(d.factoryV4Proxy).upgradeToAndCall(fresh.factoryV4Impl, "");
+        console.log("| V4 proxy upgraded to                          |", fresh.factoryV4Impl);
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Redeploy Complete ===");
+        console.log("Proxy addresses are UNCHANGED - no launchpad whitelisting or integrator action needed.");
+        console.log("Existing deployed tokens keep pointing at the OLD master fee handler.");
+        console.log("Update the per-chain manifest with these addresses, then run `just export-deployments`:");
+        console.log("  TOKEN_IMPL                             :", fresh.tokenImpl);
+        console.log("  TOKEN_SNIPER_PROTECTED_IMPL            :", fresh.tokenSniperImpl);
+        console.log("  TAXABLE_TOKEN_V2_IMPL                  :", fresh.taxTokenV2Impl);
+        console.log("  TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL :", fresh.taxTokenV2SniperImpl);
+        console.log("  TAXABLE_TOKEN_IMPL                     :", fresh.taxTokenV4Impl);
+        console.log("  TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL    :", fresh.taxTokenV4SniperImpl);
+        console.log("  FACTORY_UNIV2_UNIFIED_IMPL             :", fresh.factoryV2Impl);
+        console.log("  FACTORY_UNIV4_UNIFIED_IMPL             :", fresh.factoryV4Impl);
+    }
+}

--- a/script/RedeployTaxTokensAndUpgradeFactories.s.sol
+++ b/script/RedeployTaxTokensAndUpgradeFactories.s.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {LivoTaxableTokenUniV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {LivoTaxableTokenUniV2SniperProtected} from "src/tokens/LivoTaxableTokenUniV2SniperProtected.sol";
+import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+import {LivoTaxableTokenUniV4SniperProtected} from "src/tokens/LivoTaxableTokenUniV4SniperProtected.sol";
+import {LivoFactoryUniV2Unified} from "src/factories/LivoFactoryUniV2Unified.sol";
+import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
+import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @title Redeploy all tax-token implementations and upgrade BOTH unified factory proxies
+/// @notice Wraps up the rollout for the `setTaxBps` feature added to `LivoTaxableToken`.
+///         Both V2 and V4 tax-token families inherit the shared abstract, so all four tax-token
+///         implementations need a fresh bytecode and both unified factories need to be repointed
+///         at the new impls. Non-tax token implementations (`TOKEN_IMPL`,
+///         `TOKEN_SNIPER_PROTECTED_IMPL`) are NOT touched — they don't inherit `LivoTaxableToken`.
+///
+///         Single broadcast, six new deployments + two proxy upgrades:
+///         1. `LivoTaxableTokenUniV2`
+///         2. `LivoTaxableTokenUniV2SniperProtected`
+///         3. `LivoTaxableTokenUniV4`
+///         4. `LivoTaxableTokenUniV4SniperProtected`
+///         5. `LivoFactoryUniV2Unified` impl wired to (1) and (2) plus unchanged non-tax pieces.
+///         6. `LivoFactoryUniV4Unified` impl wired to (3) and (4) plus unchanged non-tax pieces.
+///         7. `upgradeToAndCall(newV2FactoryImpl, "")` on the existing V2 UUPS proxy.
+///         8. `upgradeToAndCall(newV4FactoryImpl, "")` on the existing V4 UUPS proxy.
+///
+///         Proxy addresses are UNCHANGED — launchpad's `whitelistedFactories` entries stay valid;
+///         integrators see no address change. No init data is passed; no new storage was added to
+///         the factories (`setTaxBps` is on the tokens, not the factories).
+///
+///         The broadcaster MUST be the proxy owner on BOTH proxies. If not, `_authorizeUpgrade`
+///         reverts with `OwnableUnauthorizedAccount(broadcaster)` and the whole script reverts.
+///
+///         Pre-broadcast sanity: confirms both V2 and V4 tax-token sources import the right
+///         per-chain `DeploymentAddresses`. Run `just taxtokenaddresses` before deploying to Sepolia.
+///
+///         Post-broadcast: update `TAXABLE_TOKEN_V2_IMPL`, `TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL`,
+///         `TAXABLE_TOKEN_IMPL`, `TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL`, `FACTORY_UNIV2_UNIFIED_IMPL`,
+///         and `FACTORY_UNIV4_UNIFIED_IMPL` in `src/config/deployments.<chain>.sol`, then run
+///         `just export-deployments`.
+///
+/// @dev    Run with:
+///         forge script RedeployTaxTokensAndUpgradeFactories --rpc-url <mainnet|sepolia> \
+///             --verify --account livo.dev --slow --broadcast
+contract RedeployTaxTokensAndUpgradeFactories is Script {
+    /// @dev Per-chain addresses needed to wire the new factory implementations and target the proxy
+    ///      upgrades. Pulled from `src/config/deployments.<chain>.sol`.
+    struct Deps {
+        // Proxies to upgrade
+        address factoryV2Proxy;
+        address factoryV4Proxy;
+        // Shared inputs reused by both fresh factory impls
+        address launchpad;
+        address bondingCurve;
+        address graduatorV2;
+        address graduatorV4;
+        address masterFeeHandler;
+        // Unchanged non-tax token impls — reused as-is when wiring the new factories
+        address tokenImpl;
+        address tokenSniperImpl;
+    }
+
+    /// @dev Addresses emitted by this script (for logging + manifest updates).
+    struct FreshDeployments {
+        address taxTokenV2Impl;
+        address taxTokenV2SniperImpl;
+        address taxTokenV4Impl;
+        address taxTokenV4SniperImpl;
+        address factoryV2Impl;
+        address factoryV4Impl;
+    }
+
+    function _getDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsMainnet.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsMainnet.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                bondingCurve: DeploymentsMainnet.BONDING_CURVE,
+                graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+        } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsSepolia.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsSepolia.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                bondingCurve: DeploymentsSepolia.BONDING_CURVE,
+                graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+        } else {
+            revert("Unsupported chain");
+        }
+
+        require(d.factoryV2Proxy != address(0), "manifest: FACTORY_UNIV2_UNIFIED missing");
+        require(d.factoryV4Proxy != address(0), "manifest: FACTORY_UNIV4_UNIFIED missing");
+        require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
+        require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
+        require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
+        require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
+        require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
+        require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
+    }
+
+    function run() public {
+        Deps memory d = _getDeps();
+        FreshDeployments memory fresh;
+
+        // Catch wrong manifest addresses pointing at non-Livo contracts before we waste deploys.
+        address v2ProxyOwner = LivoFactoryUniV2Unified(d.factoryV2Proxy).owner();
+        address v4ProxyOwner = LivoFactoryUniV4Unified(d.factoryV4Proxy).owner();
+        require(v2ProxyOwner != address(0), "V2 proxy not initialized");
+        require(v4ProxyOwner != address(0), "V4 proxy not initialized");
+        // Same key is expected to own both proxies; this is a soft sanity check, not a hard
+        // protocol invariant.
+        require(v2ProxyOwner == v4ProxyOwner, "V2 and V4 proxy owners differ; review before upgrading");
+
+        console.log("=== Livo Tax-Token Redeploy + Both Factory Upgrades ===");
+        console.log("Chain ID:                ", block.chainid);
+        console.log("Broadcaster:             ", msg.sender);
+        console.log("Required proxy owner:    ", v2ProxyOwner);
+        console.log("V2 factory proxy:        ", d.factoryV2Proxy);
+        console.log("V4 factory proxy:        ", d.factoryV4Proxy);
+        console.log("");
+
+        vm.startBroadcast();
+
+        console.log("| Contract Name                                  | Address |");
+        console.log("| ---------------------------------------------- | --- |");
+
+        // --- Tax token implementations (4) ---
+        fresh.taxTokenV2Impl = address(new LivoTaxableTokenUniV2());
+        console.log("| LivoTaxableTokenUniV2 (new impl)              |", fresh.taxTokenV2Impl);
+
+        fresh.taxTokenV2SniperImpl = address(new LivoTaxableTokenUniV2SniperProtected());
+        console.log("| LivoTaxableTokenUniV2SniperProtected (new)    |", fresh.taxTokenV2SniperImpl);
+
+        fresh.taxTokenV4Impl = address(new LivoTaxableTokenUniV4());
+        console.log("| LivoTaxableTokenUniV4 (new impl)              |", fresh.taxTokenV4Impl);
+
+        fresh.taxTokenV4SniperImpl = address(new LivoTaxableTokenUniV4SniperProtected());
+        console.log("| LivoTaxableTokenUniV4SniperProtected (new)    |", fresh.taxTokenV4SniperImpl);
+
+        // --- Factory implementations (2) wired to the fresh tax-token impls + unchanged rest ---
+        fresh.factoryV2Impl = address(
+            new LivoFactoryUniV2Unified(
+                d.launchpad,
+                d.tokenImpl,
+                d.tokenSniperImpl,
+                fresh.taxTokenV2Impl,
+                fresh.taxTokenV2SniperImpl,
+                d.bondingCurve,
+                d.graduatorV2,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV2Unified (new impl)            |", fresh.factoryV2Impl);
+
+        fresh.factoryV4Impl = address(
+            new LivoFactoryUniV4Unified(
+                d.launchpad,
+                d.tokenImpl,
+                d.tokenSniperImpl,
+                fresh.taxTokenV4Impl,
+                fresh.taxTokenV4SniperImpl,
+                d.bondingCurve,
+                d.graduatorV4,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV4Unified (new impl)            |", fresh.factoryV4Impl);
+
+        // --- Proxy upgrades (2) ---
+        UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
+        console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
+
+        UUPSUpgradeable(d.factoryV4Proxy).upgradeToAndCall(fresh.factoryV4Impl, "");
+        console.log("| V4 proxy upgraded to                          |", fresh.factoryV4Impl);
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Redeploy Complete ===");
+        console.log("Proxy addresses are UNCHANGED - no launchpad whitelisting or integrator action needed.");
+        console.log("Update the per-chain manifest with these addresses, then run `just export-deployments`:");
+        console.log("  TAXABLE_TOKEN_V2_IMPL                  :", fresh.taxTokenV2Impl);
+        console.log("  TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL :", fresh.taxTokenV2SniperImpl);
+        console.log("  TAXABLE_TOKEN_IMPL                     :", fresh.taxTokenV4Impl);
+        console.log("  TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL    :", fresh.taxTokenV4SniperImpl);
+        console.log("  FACTORY_UNIV2_UNIFIED_IMPL             :", fresh.factoryV2Impl);
+        console.log("  FACTORY_UNIV4_UNIFIED_IMPL             :", fresh.factoryV4Impl);
+    }
+}

--- a/script/RedeployV2TaxTokensAndUpgradeFactory.s.sol
+++ b/script/RedeployV2TaxTokensAndUpgradeFactory.s.sol
@@ -142,8 +142,8 @@ contract RedeployV2TaxTokensAndUpgradeFactory is Script {
         );
         console.log("| LivoFactoryUniV2Unified (new impl)            |", fresh.factoryV2Impl);
 
-        UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
-        console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
+        // UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
+        // console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
 
         vm.stopBroadcast();
 

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -15,7 +15,7 @@ library DeploymentsMainnet {
     address internal constant BONDING_CURVE = 0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23;
     address internal constant GRADUATOR_UNIV2 = 0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC;
     address internal constant GRADUATOR_UNIV4 = 0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944;
-    address internal constant MASTER_FEE_HANDLER = 0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC;
+    address internal constant MASTER_FEE_HANDLER = 0x48b3F72469cDba3986A36cE6C47e6Cb027dCCcF2;
 
     address internal constant SWAP_HOOK = 0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc;
     address internal constant SWAP_HOOK_0P5 = 0x068241d20c59980AbEAeDED990d2441F05f5C0Cc;

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -22,16 +22,16 @@ library DeploymentsMainnet {
     address internal constant QUOTER = 0x035693207fb473358b41A81FF09445dB1f3889D1;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0x79E3a3473ad2d9285A7C87ACfb4A5C871396240d;
-    address internal constant TAXABLE_TOKEN_IMPL = 0xF232d7D7B552B3B981FE91B13F715B3c1F075A13;
+    address internal constant TOKEN_IMPL = 0x974F9139D56DAE3D44714Cd24632BB9Bf69139E2;
+    address internal constant TAXABLE_TOKEN_IMPL = 0x805bE40375F5263321Be2B1B16524709F0FE5726;
 
     /// @notice Sniper-protected token implementations
-    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0xA6d75e290b12f6c2E90C82bF431bBEb4EF5D4862;
-    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x95A52bF07bAB218712b66148D48B2EaD44610dE7;
+    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0xeebA991E97304a10c3409495F6DFbB0f7CA5fAe5;
+    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x8907cA768EcaCbBb7D2209FEE6b190EA71124A12;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0xfb536Abb27f52DBb62DD91f789C6B9a12C48441b;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0xE8296eC8061af577DD1f06263E9B07A35d6a084F;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x87d412A2f3976B7933D8a73858218B7147775e2A;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x1d20ae8983E44DBCcAF947a8f9998835E07573D3;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -41,8 +41,8 @@ library DeploymentsMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x6Cc0EC8f989bd39A472D0690e24d5249a3642Eb4;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x944f141Cd97c5126D118Df2d0f36867a1D63B186;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x14634CBf79c4432E75E1494B8D58984FaD4e4fEE;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x41241EcD235cd7e0e35a6c79Ba235C1D8BD7DffC;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -31,8 +31,8 @@ library DeploymentsSepolia {
     address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x8289D631513B3766D79820682b864a47923c60a0;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x6b7E55f0Dc9C5841A5bACDDCf23ccDcb28afd040;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0xAF58def3c5663716016Ffa7C9f6f69B359cDE4D8;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x25d2F64271B9f5715eE7D1359e1A290cc208410F;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x5AF555eCB77fB9ff165D38170a3917D90B57084c;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -42,7 +42,7 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x279C76a0D562D597eFa8f2C811210AF4fFB68F51;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x25413997d736C7cb7D044A6A6983420dB00Ef8f8;
     address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x9bd879588A942308bee973B79311680266B85707;
 
     // --- Accounts ---

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -16,7 +16,7 @@ library DeploymentsSepolia {
     address internal constant BONDING_CURVE = 0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5;
     address internal constant GRADUATOR_UNIV2 = 0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691;
     address internal constant GRADUATOR_UNIV4 = 0x85fE2051413a4b80b904f05841d1142FeF7f789c;
-    address internal constant MASTER_FEE_HANDLER = 0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f;
+    address internal constant MASTER_FEE_HANDLER = 0x3dD70c06e04A10768aAd7208f119e73E4eD3e306;
 
     address internal constant SWAP_HOOK = 0x0591a87D3a56797812C4DA164C1B005c545400Cc;
     address internal constant SWAP_HOOK_0P5 = 0xC04Bb5bA43795330e54efaC7244ce40318FD80cc;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -23,16 +23,16 @@ library DeploymentsSepolia {
     address internal constant QUOTER = 0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0x2C0a167A0f83E7969cA22B386Fe72BA608af9B4a;
-    address internal constant TAXABLE_TOKEN_IMPL = 0xCcc99765d31A6023E279b98f19e3dFB8430D401f;
+    address internal constant TOKEN_IMPL = 0x7A2F3A309f070c8F45E541e1069BaEF5dA7A1512;
+    address internal constant TAXABLE_TOKEN_IMPL = 0x57Bb01ac46B9a2DfC3C05cE47d692e4b729BDCBe;
 
     /// @notice Sniper-protected token implementations
-    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0xE90318026ea1D2865A5359386a75B75acB054B52;
-    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x791A685EDCE8839C29Fe87Ad8b4ea84E3D1d98C0;
+    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0xdF5CD2fc0078147Fce85bc2170250eC6339026a0;
+    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x8289D631513B3766D79820682b864a47923c60a0;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x90FcBc67563B6e6950439a28D32964a47503Eb35;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x9d73bb0fF3DbdCd727fD84E8CB424Ad83920C202;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x6b7E55f0Dc9C5841A5bACDDCf23ccDcb28afd040;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0xAF58def3c5663716016Ffa7C9f6f69B359cDE4D8;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -42,8 +42,8 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x60653929Cc5b5053e428311FD4182882244901b0;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x76133EFc6563047e9D990c902063e1746601e2D3;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x279C76a0D562D597eFa8f2C811210AF4fFB68F51;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x9bd879588A942308bee973B79311680266B85707;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -31,8 +31,8 @@ library DeploymentsSepolia {
     address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x8289D631513B3766D79820682b864a47923c60a0;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x25d2F64271B9f5715eE7D1359e1A290cc208410F;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x5AF555eCB77fB9ff165D38170a3917D90B57084c;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0xE9081F5db8D4ac5193eD4D987B93A54916175Fa7;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x7bF9a2098DC5DC0bBD22552372a8DEDE37751903;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -42,7 +42,7 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x25413997d736C7cb7D044A6A6983420dB00Ef8f8;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x63495eE6A0044F263ACA029e1432930c124e91da;
     address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x9bd879588A942308bee973B79311680266B85707;
 
     // --- Accounts ---

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -31,8 +31,8 @@ library DeploymentsSepolia {
     address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x8289D631513B3766D79820682b864a47923c60a0;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0xE9081F5db8D4ac5193eD4D987B93A54916175Fa7;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x7bF9a2098DC5DC0bBD22552372a8DEDE37751903;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x40C8Aa070fBAcA3467BADA8Ec6039308fd8eb462;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x2C358C8C09BA9B9a70916b8905A644f9e4A1606B;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -42,7 +42,7 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x63495eE6A0044F263ACA029e1432930c124e91da;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x01bf709952FC4f7caCF98240F1C2086d56f135B7;
     address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x9bd879588A942308bee973B79311680266B85707;
 
     // --- Accounts ---

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -237,8 +237,8 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///      strictly after `TokenLaunched`, and the deployer buy events fire last.
     /// @dev Skips master-handler registration when `token.feeHandler()` already points at a
     ///      direct receiver (returned by `_resolveFeeHandlerForInit` on the derived factory).
-    ///      Those tokens never have a registered config on the master handler; receiver rotation
-    ///      goes through `LivoToken.setFeeHandler` instead.
+    ///      Those tokens never have a registered config on the master handler, and the receiver
+    ///      address is immutable post-init.
     function _finalizeCreation(address token, FeeShare[] calldata feeReceivers, SupplyShare[] calldata supplyShares)
         internal
     {

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -235,10 +235,16 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     /// @dev Shared postamble: asks the token to self-register its fee config with the master
     ///      handler, then performs the deployer buy (if any). Event order: `SharesUpdated` fires
     ///      strictly after `TokenLaunched`, and the deployer buy events fire last.
+    /// @dev Skips master-handler registration when `token.feeHandler()` already points at a
+    ///      direct receiver (returned by `_resolveFeeHandlerForInit` on the derived factory).
+    ///      Those tokens never have a registered config on the master handler; receiver rotation
+    ///      goes through `LivoToken.setFeeHandler` instead.
     function _finalizeCreation(address token, FeeShare[] calldata feeReceivers, SupplyShare[] calldata supplyShares)
         internal
     {
-        ILivoToken(token).registerFees(feeReceivers);
+        if (ILivoToken(token).feeHandler() == address(MASTER_FEE_HANDLER)) {
+            ILivoToken(token).registerFees(feeReceivers);
+        }
         if (msg.value > 0) _buyAndDistribute(token, supplyShares);
     }
 
@@ -254,20 +260,25 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///      `InitializeParams` for the caller to pass to the impl-specific `initialize()` overload.
     ///      `TokenCreated` is emitted BEFORE `initialize()` because the indexer creates the TokenData
     ///      entity from that event; events emitted inside `initialize()` depend on it.
+    /// @dev The `feeHandler` address baked into both the `TokenCreated` event and `InitializeParams`
+    ///      comes from `_resolveFeeHandlerForInit`. Defaults to the master fee handler; derived
+    ///      factories override the hook to bypass the master handler for specific configurations
+    ///      (currently V2 taxable + single-direct-receiver).
     function _cloneAndCreateToken(
         address impl,
         string calldata name,
         string calldata symbol,
         bytes32 salt,
-        address tokenOwner
+        address tokenOwner,
+        FeeShare[] calldata feeReceivers
     ) internal returns (address token, ILivoToken.InitializeParams memory params) {
         token = Clones.cloneDeterministic(impl, salt);
         // forge-lint: disable-next-line(unsafe-typecast)
         require(uint16(uint160(token)) == 0x1110, InvalidTokenAddress());
 
-        emit TokenCreated(
-            token, name, symbol, tokenOwner, address(LAUNCHPAD), address(GRADUATOR), address(MASTER_FEE_HANDLER)
-        );
+        address feeHandler = _resolveFeeHandlerForInit(impl, feeReceivers);
+
+        emit TokenCreated(token, name, symbol, tokenOwner, address(LAUNCHPAD), address(GRADUATOR), feeHandler);
 
         params = ILivoToken.InitializeParams({
             name: name,
@@ -275,8 +286,26 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
             tokenOwner: tokenOwner,
             graduator: address(GRADUATOR),
             launchpad: address(LAUNCHPAD),
-            feeHandler: address(MASTER_FEE_HANDLER)
+            feeHandler: feeHandler
         });
+    }
+
+    /// @dev Resolves the `feeHandler` baked into the token at init. Defaults to the master fee
+    ///      handler; derived factories override to return a single direct receiver's address when
+    ///      they want to bypass the master handler entirely (currently `LivoFactoryUniV2Unified`
+    ///      for V2 taxable + single-direct-receiver). When this hook returns a value other than
+    ///      `address(MASTER_FEE_HANDLER)`, `_finalizeCreation` automatically skips
+    ///      `registerFees`, and the derived factory should emit `DirectSingleFeeReceiver` so the
+    ///      indexer learns about it.
+    function _resolveFeeHandlerForInit(address impl, FeeShare[] calldata feeReceivers)
+        internal
+        view
+        virtual
+        returns (address)
+    {
+        impl; // silence unused-var warning when override doesn't use it
+        feeReceivers;
+        return address(MASTER_FEE_HANDLER);
     }
 
     /// @dev Validates a tax config: enforces sentinel consistency (zero duration ⇒ zero bps),
@@ -331,14 +360,15 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string calldata symbol,
         bytes32 salt,
         address tokenOwner,
+        FeeShare[] calldata feeReceivers,
         TaxConfigInit calldata taxCfg,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         address impl = _previewTokenImplementation(taxCfg, antiSniperCfg);
         if (_isTaxConfigured(taxCfg)) {
-            token = _initializeTaxToken(impl, name, symbol, salt, tokenOwner, taxCfg, antiSniperCfg);
+            token = _initializeTaxToken(impl, name, symbol, salt, tokenOwner, feeReceivers, taxCfg, antiSniperCfg);
         } else {
-            token = _initializeNonTaxToken(impl, name, symbol, salt, tokenOwner, antiSniperCfg);
+            token = _initializeNonTaxToken(impl, name, symbol, salt, tokenOwner, feeReceivers, antiSniperCfg);
         }
     }
 
@@ -352,11 +382,12 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string calldata symbol,
         bytes32 salt,
         address tokenOwner,
+        FeeShare[] calldata feeReceivers,
         TaxConfigInit calldata taxCfg,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         ILivoToken.InitializeParams memory params;
-        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner);
+        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner, feeReceivers);
 
         if (_isAntiSniperConfigured(antiSniperCfg)) {
             ILivoTaxableTokenSniperProtected(payable(token)).initialize(params, taxCfg, antiSniperCfg);
@@ -374,10 +405,11 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string calldata symbol,
         bytes32 salt,
         address tokenOwner,
+        FeeShare[] calldata feeReceivers,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         ILivoToken.InitializeParams memory params;
-        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner);
+        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner, feeReceivers);
 
         if (_isAntiSniperConfigured(antiSniperCfg)) {
             LivoTokenSniperProtected(token).initialize(params, antiSniperCfg);

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -232,13 +232,10 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         }
     }
 
-    /// @dev Shared postamble: asks the token to self-register its fee config with the master
-    ///      handler, then performs the deployer buy (if any). Event order: `SharesUpdated` fires
-    ///      strictly after `TokenLaunched`, and the deployer buy events fire last.
-    /// @dev Skips master-handler registration when `token.feeHandler()` already points at a
-    ///      direct receiver (returned by `_resolveFeeHandlerForInit` on the derived factory).
-    ///      Those tokens never have a registered config on the master handler, and the receiver
-    ///      address is immutable post-init.
+    /// @dev Shared postamble: registers the token's fee config with the master handler and runs
+    ///      the deployer buy. Event order: `SharesUpdated` after `TokenLaunched`, deployer-buy
+    ///      events last. Registration is skipped when `_resolveFeeHandlerForInit` bypassed the
+    ///      master handler (direct-receiver path).
     function _finalizeCreation(address token, FeeShare[] calldata feeReceivers, SupplyShare[] calldata supplyShares)
         internal
     {
@@ -255,15 +252,12 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         require(bytes(symbol).length <= 32, InvalidNameOrSymbol());
     }
 
-    /// @dev Clones the resolved token implementation deterministically, enforces the `0x1110` vanity
-    ///      suffix, emits `TokenCreated`, and returns the freshly-deployed token plus a fully-populated
-    ///      `InitializeParams` for the caller to pass to the impl-specific `initialize()` overload.
-    ///      `TokenCreated` is emitted BEFORE `initialize()` because the indexer creates the TokenData
-    ///      entity from that event; events emitted inside `initialize()` depend on it.
-    /// @dev The `feeHandler` address baked into both the `TokenCreated` event and `InitializeParams`
-    ///      comes from `_resolveFeeHandlerForInit`. Defaults to the master fee handler; derived
-    ///      factories override the hook to bypass the master handler for specific configurations
-    ///      (currently V2 taxable + single-direct-receiver).
+    /// @dev Clones the impl deterministically, enforces the `0x1110` vanity suffix, emits
+    ///      `TokenCreated`, and returns the token plus a populated `InitializeParams`.
+    ///      `TokenCreated` MUST fire before `initialize()` — the indexer creates the TokenData
+    ///      entity from it, and `initialize()`'s events depend on it.
+    ///      The baked-in `feeHandler` comes from `_resolveFeeHandlerForInit` (master by default;
+    ///      overridden for the V2 taxable + single-direct-receiver path).
     function _cloneAndCreateToken(
         address impl,
         string calldata name,
@@ -290,13 +284,10 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         });
     }
 
-    /// @dev Resolves the `feeHandler` baked into the token at init. Defaults to the master fee
-    ///      handler; derived factories override to return a single direct receiver's address when
-    ///      they want to bypass the master handler entirely (currently `LivoFactoryUniV2Unified`
-    ///      for V2 taxable + single-direct-receiver). When this hook returns a value other than
-    ///      `address(MASTER_FEE_HANDLER)`, `_finalizeCreation` automatically skips
-    ///      `registerFees`, and the derived factory should emit `DirectSingleFeeReceiver` so the
-    ///      indexer learns about it.
+    /// @dev Resolves the `feeHandler` baked into the token at init. Defaults to the master
+    ///      handler; overrides may bypass it (currently `LivoFactoryUniV2Unified` for V2 taxable
+    ///      + single-direct-receiver). When this returns a non-master address, `_finalizeCreation`
+    ///      skips `registerFees` and the derived factory should emit `DirectSingleFeeReceiver`.
     function _resolveFeeHandlerForInit(address impl, FeeShare[] calldata feeReceivers)
         internal
         view

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -50,8 +50,8 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
     ///      swapback path's `_accrueFees` then becomes a plain ETH transfer to that address, so
     ///      Dexscreener-style scanners no longer flag the swap-back transfer as an external call
     ///      into an unknown contract. The master handler is never registered for these tokens
-    ///      (`_finalizeCreation` skips `registerFees`); admin rotates the receiver via
-    ///      `LivoToken.setFeeHandler`.
+    ///      (`_finalizeCreation` skips `registerFees`); the receiver baked in at init time is
+    ///      immutable for the life of the token.
     ///
     ///      Trade-offs:
     ///      - No fallback like the master handler's pending-claims path: a malicious contract

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -45,18 +45,13 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
     }
 
     /// @inheritdoc LivoFactoryAbstract
-    /// @dev When a V2 *taxable* token is deployed with exactly one fee receiver whose
-    ///      `directFeesEnabled` is true, point `token.feeHandler` straight at the receiver. The
-    ///      swapback path's `_accrueFees` then becomes a plain ETH transfer to that address, so
-    ///      Dexscreener-style scanners no longer flag the swap-back transfer as an external call
-    ///      into an unknown contract. The master handler is never registered for these tokens
-    ///      (`_finalizeCreation` skips `registerFees`); the receiver baked in at init time is
-    ///      immutable for the life of the token.
-    ///
-    ///      Trade-offs:
-    ///      - No fallback like the master handler's pending-claims path: a malicious contract
-    ///        receiver that reverts on `receive()` can DoS swap-backs.
-    ///      - `setShares` is unavailable: routing is locked to a single receiver address.
+    /// @dev V2 taxable + exactly one fee receiver with `directFeesEnabled = true`: point
+    ///      `token.feeHandler` straight at the receiver. Swap-backs become a plain ETH transfer
+    ///      to that address, so scanners no longer flag the transfer as an external call into an
+    ///      unknown contract. The receiver is immutable for the life of the token.
+    ///      Trade-offs: no pending-claims fallback (the token's `_accrueFees` swallows transfer
+    ///      failures, so ETH stays on the token until the next swap-back); `setShares` is
+    ///      unavailable; routing is locked to a single address.
     function _resolveFeeHandlerForInit(address impl, FeeShare[] calldata feeReceivers)
         internal
         view
@@ -72,13 +67,11 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
 
     /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
 
-    /// @notice Deploys a V2-family Livo token and registers it in the launchpad.
-    ///         Dispatches between four implementations based on `taxCfg` and `antiSniperCfg`.
-    ///         The per-token fee config is registered with the master fee handler at deploy time,
-    ///         UNLESS the V2 taxable + single-direct-receiver path is taken (see
-    ///         `_resolveFeeHandlerForInit`), in which case `token.feeHandler` points at the
-    ///         receiver and `DirectSingleFeeReceiver` is emitted instead.
-    ///         If `msg.value > 0`, buys supply and distributes it across `supplyShares`.
+    /// @notice Deploys a V2-family Livo token and registers it in the launchpad. Dispatches
+    ///         between four impls based on `taxCfg` and `antiSniperCfg`. Fee config is registered
+    ///         with the master handler unless the V2 taxable + single-direct-receiver path is
+    ///         taken (see `_resolveFeeHandlerForInit`) — in that case `DirectSingleFeeReceiver`
+    ///         fires instead. If `msg.value > 0`, buys supply and distributes per `supplyShares`.
     function createToken(
         string calldata name,
         string calldata symbol,
@@ -97,9 +90,8 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
 
         token = _dispatchAndInitialize(name, symbol, salt, tokenOwner, feeReceivers, taxCfg, antiSniperCfg);
 
-        // Emit DirectSingleFeeReceiver iff the resolver picked the direct path. Reading the
-        // initialized `feeHandler` keeps the hook as the single source of truth (no risk of the
-        // event drifting from what was actually baked into the token).
+        // Read the initialized `feeHandler` so the resolver hook remains the single source of
+        // truth (the event can't drift from what was actually baked into the token).
         if (ILivoToken(token).feeHandler() != address(MASTER_FEE_HANDLER)) {
             emit DirectSingleFeeReceiver(token, feeReceivers[0].account);
         }

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {AntiSniperConfigs} from "src/tokens/SniperProtection.sol";
 import {TaxConfigInit} from "src/interfaces/ILivoTaxableToken.sol";
+import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {LivoFactoryAbstract} from "src/factories/LivoFactoryAbstract.sol";
 
 /// @notice Unified factory for the Uniswap V2 token family. Dispatches between four token
@@ -43,11 +44,40 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         return 500;
     }
 
+    /// @inheritdoc LivoFactoryAbstract
+    /// @dev When a V2 *taxable* token is deployed with exactly one fee receiver whose
+    ///      `directFeesEnabled` is true, point `token.feeHandler` straight at the receiver. The
+    ///      swapback path's `_accrueFees` then becomes a plain ETH transfer to that address, so
+    ///      Dexscreener-style scanners no longer flag the swap-back transfer as an external call
+    ///      into an unknown contract. The master handler is never registered for these tokens
+    ///      (`_finalizeCreation` skips `registerFees`); admin rotates the receiver via
+    ///      `LivoToken.setFeeHandler`.
+    ///
+    ///      Trade-offs:
+    ///      - No fallback like the master handler's pending-claims path: a malicious contract
+    ///        receiver that reverts on `receive()` can DoS swap-backs.
+    ///      - `setShares` is unavailable: routing is locked to a single receiver address.
+    function _resolveFeeHandlerForInit(address impl, FeeShare[] calldata feeReceivers)
+        internal
+        view
+        override
+        returns (address)
+    {
+        bool isTaxableImpl = impl == TOKEN_IMPL_TAX || impl == TOKEN_IMPL_TAX_ANTISNIPER;
+        if (isTaxableImpl && feeReceivers.length == 1 && feeReceivers[0].directFeesEnabled) {
+            return feeReceivers[0].account;
+        }
+        return address(MASTER_FEE_HANDLER);
+    }
+
     /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
 
     /// @notice Deploys a V2-family Livo token and registers it in the launchpad.
     ///         Dispatches between four implementations based on `taxCfg` and `antiSniperCfg`.
-    ///         The per-token fee config is registered with the master fee handler at deploy time.
+    ///         The per-token fee config is registered with the master fee handler at deploy time,
+    ///         UNLESS the V2 taxable + single-direct-receiver path is taken (see
+    ///         `_resolveFeeHandlerForInit`), in which case `token.feeHandler` points at the
+    ///         receiver and `DirectSingleFeeReceiver` is emitted instead.
     ///         If `msg.value > 0`, buys supply and distributes it across `supplyShares`.
     function createToken(
         string calldata name,
@@ -65,7 +95,14 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         _validateAntiSniperConfig(antiSniperCfg);
         _validateTaxConfig(taxCfg);
 
-        token = _dispatchAndInitialize(name, symbol, salt, tokenOwner, taxCfg, antiSniperCfg);
+        token = _dispatchAndInitialize(name, symbol, salt, tokenOwner, feeReceivers, taxCfg, antiSniperCfg);
+
+        // Emit DirectSingleFeeReceiver iff the resolver picked the direct path. Reading the
+        // initialized `feeHandler` keeps the hook as the single source of truth (no risk of the
+        // event drifting from what was actually baked into the token).
+        if (ILivoToken(token).feeHandler() != address(MASTER_FEE_HANDLER)) {
+            emit DirectSingleFeeReceiver(token, feeReceivers[0].account);
+        }
 
         LAUNCHPAD.launchToken(token, BONDING_CURVE);
         _finalizeCreation(token, feeReceivers, supplyShares);

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -60,7 +60,7 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         _validateTaxConfig(taxCfg);
 
         address tokenOwner = renounceOwnership_ ? address(0) : msg.sender;
-        token = _dispatchAndInitialize(name, symbol, salt, tokenOwner, taxCfg, antiSniperCfg);
+        token = _dispatchAndInitialize(name, symbol, salt, tokenOwner, feeReceivers, taxCfg, antiSniperCfg);
 
         LAUNCHPAD.launchToken(token, BONDING_CURVE);
         _finalizeCreation(token, feeReceivers, supplyShares);

--- a/src/feeHandlers/LivoMasterFeeHandler.sol
+++ b/src/feeHandlers/LivoMasterFeeHandler.sol
@@ -62,35 +62,29 @@ contract LivoMasterFeeHandler is ILivoMasterFeeHandler, Ownable2Step, Reentrancy
 
     ////////////////////////////// EXTERNAL FUNCTIONS ///////////////////////////////////
 
-    /// @notice Deposits ETH fees for `token`. For direct receivers the slice is forwarded
-    ///         synchronously; for claimable recipients the accumulator is advanced.
-    /// @dev Kept for callers that need to attribute a deposit to a token other than `msg.sender`
-    ///      (e.g. router/forwarder integrations). Token contracts themselves can instead send ETH
-    ///      with empty calldata, which hits `receive()` and is attributed via `msg.sender`.
-    /// @dev `CreatorFeesDeposited` is emitted before any forward attempt for non-zero deposits;
-    ///      zero-value calls are no-ops and emit nothing. There is intentionally no explicit
-    ///      registration check on this swap-hot path: registered configs always contain at least one
-    ///      recipient, while an unregistered positive-value deposit reaches `_depositSingle` and
-    ///      reverts with Solidity's array-out-of-bounds panic when reading `claimableRecipients[0]`.
-    ///      The transient `nonReentrant` guard is shared with `setShares`, `claim` and `receive` —
-    ///      any nested call from a direct-receiver hook into those functions reverts, which
-    ///      prevents iteration corruption in `_depositSplit`.
+    /// @notice Deposits ETH fees for `token`. Direct slices forward synchronously; claimable
+    ///         recipients advance the accumulator.
+    /// @dev Use this when the caller needs to attribute the deposit to a token other than itself
+    ///      (e.g. router/forwarder integrations). Tokens can also push ETH with empty calldata,
+    ///      hitting `receive()` and being attributed via `msg.sender`.
+    /// @dev Zero-value calls are no-ops. No explicit registration check on this swap-hot path —
+    ///      unregistered positive deposits revert in `_depositSingle` via OOB on
+    ///      `claimableRecipients[0]`. The shared `nonReentrant` transient guard (with `setShares`,
+    ///      `claim`, `receive`) blocks direct-receiver re-entry that would corrupt iteration.
     function depositFees(address token) external payable nonReentrant {
         _depositFees(token);
     }
 
-    /// @notice Plain ETH receiver: attributes the deposit to `msg.sender` (the calling token).
-    /// @dev Lets tokens push fees with a bare value-call (`feeHandler.call{value: x}("")`) instead
-    ///      of `depositFees(address(this))` — the `address(this)` argument was redundant. Shares
-    ///      the same `nonReentrant` transient guard as `depositFees`, `setShares` and `claim`.
-    /// @dev Reverts for non-registered tokens with a clear OOB panic from the attempted read of `claimableRecipients[0]` in `_depositSingle`,
-    ///      which is an acceptable failure mode for misconfigured tokens.
+    /// @notice Plain ETH receiver. Attributes the deposit to `msg.sender` (the calling token),
+    ///         so tokens can push fees with a bare value-call instead of `depositFees(address(this))`.
+    ///         Same `nonReentrant` guard as `depositFees` / `setShares` / `claim`.
+    /// @dev Unregistered senders revert with an OOB panic from `_depositSingle` reading
+    ///      `claimableRecipients[0]` — acceptable failure mode for misconfigured tokens.
     receive() external payable nonReentrant {
         _depositFees(msg.sender);
     }
 
-    /// @dev Shared deposit body for `depositFees` and `receive`. Caller must hold the `nonReentrant`
-    ///      guard.
+    /// @dev Shared body for `depositFees` and `receive`. Caller must hold the `nonReentrant` guard.
     function _depositFees(address token) internal {
         if (msg.value == 0) return;
 

--- a/src/feeHandlers/LivoMasterFeeHandler.sol
+++ b/src/feeHandlers/LivoMasterFeeHandler.sol
@@ -64,18 +64,38 @@ contract LivoMasterFeeHandler is ILivoMasterFeeHandler, Ownable2Step, Reentrancy
 
     /// @notice Deposits ETH fees for `token`. For direct receivers the slice is forwarded
     ///         synchronously; for claimable recipients the accumulator is advanced.
+    /// @dev Kept for callers that need to attribute a deposit to a token other than `msg.sender`
+    ///      (e.g. router/forwarder integrations). Token contracts themselves can instead send ETH
+    ///      with empty calldata, which hits `receive()` and is attributed via `msg.sender`.
     /// @dev `CreatorFeesDeposited` is emitted before any forward attempt for non-zero deposits;
     ///      zero-value calls are no-ops and emit nothing. There is intentionally no explicit
     ///      registration check on this swap-hot path: registered configs always contain at least one
     ///      recipient, while an unregistered positive-value deposit reaches `_depositSingle` and
     ///      reverts with Solidity's array-out-of-bounds panic when reading `claimableRecipients[0]`.
-    ///      The transient `nonReentrant` guard is shared with `setShares` and `claim` — any nested
-    ///      call from a direct-receiver hook into those functions reverts, which prevents iteration
-    ///      corruption in `_depositSplit`.
+    ///      The transient `nonReentrant` guard is shared with `setShares`, `claim` and `receive` —
+    ///      any nested call from a direct-receiver hook into those functions reverts, which
+    ///      prevents iteration corruption in `_depositSplit`.
     function depositFees(address token) external payable nonReentrant {
+        _depositFees(token);
+    }
+
+    /// @notice Plain ETH receiver: attributes the deposit to `msg.sender` (the calling token).
+    /// @dev Lets tokens push fees with a bare value-call (`feeHandler.call{value: x}("")`) instead
+    ///      of `depositFees(address(this))` — the `address(this)` argument was redundant. Shares
+    ///      the same `nonReentrant` transient guard as `depositFees`, `setShares` and `claim`.
+    /// @dev Reverts for non-registered tokens with a clear OOB panic from the attempted read of `claimableRecipients[0]` in `_depositSingle`, 
+    ///      which is an acceptable failure mode for misconfigured tokens.
+    receive() external payable nonReentrant {
+        _depositFees(msg.sender);
+    }
+
+    /// @dev Shared deposit body for `depositFees` and `receive`. Caller must hold the `nonReentrant`
+    ///      guard.
+    function _depositFees(address token) internal {
+        if (msg.value == 0) return;
+
         TokenFeeConfigLib.Config storage cfg = _configs[token];
 
-        if (msg.value == 0) return;
         emit CreatorFeesDeposited(token, msg.value);
 
         if (!cfg.isSplit) {

--- a/src/feeHandlers/LivoMasterFeeHandler.sol
+++ b/src/feeHandlers/LivoMasterFeeHandler.sol
@@ -83,7 +83,7 @@ contract LivoMasterFeeHandler is ILivoMasterFeeHandler, Ownable2Step, Reentrancy
     /// @dev Lets tokens push fees with a bare value-call (`feeHandler.call{value: x}("")`) instead
     ///      of `depositFees(address(this))` — the `address(this)` argument was redundant. Shares
     ///      the same `nonReentrant` transient guard as `depositFees`, `setShares` and `claim`.
-    /// @dev Reverts for non-registered tokens with a clear OOB panic from the attempted read of `claimableRecipients[0]` in `_depositSingle`, 
+    /// @dev Reverts for non-registered tokens with a clear OOB panic from the attempted read of `claimableRecipients[0]` in `_depositSingle`,
     ///      which is an acceptable failure mode for misconfigured tokens.
     receive() external payable nonReentrant {
         _depositFees(msg.sender);

--- a/src/interfaces/ILivoFactory.sol
+++ b/src/interfaces/ILivoFactory.sol
@@ -41,6 +41,13 @@ interface ILivoFactory {
         uint256[] amounts
     );
 
+    /// @notice Emitted only when a token is deployed with a single fee receiver whose
+    ///         `directFeesEnabled` is true AND the venue uses the direct-handler path (currently
+    ///         V2 taxable only). For these tokens `token.feeHandler() == receiver` (not the master
+    ///         fee handler), and the master fee handler is never registered. The indexer uses this
+    ///         event to seed the per-token FeeSplitterShare row and flag `isDirectFeeHandlerEOA`.
+    event DirectSingleFeeReceiver(address indexed token, address receiver);
+
     ////////////////// Errors //////////////////////
 
     error InvalidNameOrSymbol();

--- a/src/interfaces/ILivoFactory.sol
+++ b/src/interfaces/ILivoFactory.sol
@@ -41,11 +41,9 @@ interface ILivoFactory {
         uint256[] amounts
     );
 
-    /// @notice Emitted only when a token is deployed with a single fee receiver whose
-    ///         `directFeesEnabled` is true AND the venue uses the direct-handler path (currently
-    ///         V2 taxable only). For these tokens `token.feeHandler() == receiver` (not the master
-    ///         fee handler), and the master fee handler is never registered. The indexer uses this
-    ///         event to seed the per-token FeeSplitterShare row and flag `isDirectFeeHandlerEOA`.
+    /// @notice Emitted when the V2-taxable single-direct-receiver path is taken:
+    ///         `token.feeHandler() == receiver` and the master handler is never registered. The
+    ///         indexer uses this to seed FeeSplitterShare and flag `isDirectFeeHandlerEOA`.
     event DirectSingleFeeReceiver(address indexed token, address receiver);
 
     ////////////////// Errors //////////////////////

--- a/src/interfaces/ILivoTaxableToken.sol
+++ b/src/interfaces/ILivoTaxableToken.sol
@@ -26,6 +26,10 @@ interface ILivoTaxableToken is ILivoToken {
     /// @notice Initializes a taxable-token clone. Used by the factory to dispatch into either V2
     ///         or V4 concrete tax-token implementations through a single shared type.
     function initialize(ILivoToken.InitializeParams memory params, TaxConfigInit memory taxCfg) external;
+
+    /// @notice Owner-only setter for `buyTaxBps` / `sellTaxBps`. Currently enforces decrease-only —
+    ///         attempts to raise either rate revert.
+    function setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps) external;
 }
 
 /// @title ILivoTaxableTokenSniperProtected

--- a/src/interfaces/ILivoToken.sol
+++ b/src/interfaces/ILivoToken.sol
@@ -11,6 +11,11 @@ interface ILivoToken is IERC20 {
     event NewOwnerProposed(address owner, address proposedOwner, address caller);
     event OwnershipTransferred(address newOwner);
 
+    /// @notice Emitted by `setFeeHandler`. Lets the indexer rotate `TokenFeeData.feeHandler`,
+    ///         rewrite the per-token FeeSplitterShare row when this token is in direct-handler
+    ///         mode, and recompute `isDirectFeeHandlerEOA`.
+    event FeeHandlerChanged(address oldFeeHandler, address newFeeHandler);
+
     /// @notice Shared initialization parameters for Livo token clones
     struct InitializeParams {
         string name;
@@ -49,6 +54,12 @@ interface ILivoToken is IERC20 {
     /// @notice Allows the current owner to permanently renounce ownership
     function renounceOwnership() external;
 
+    /// @notice Rotates the fee handler address. Auth: current `owner` OR the launchpad owner.
+    /// @dev    Primary use case: rotate the single direct receiver of a V2-taxable token deployed
+    ///         via the direct-handler path. Pointing back at the master fee handler when the token
+    ///         was never registered there will brick swapbacks — admin's responsibility.
+    function setFeeHandler(address newFeeHandler) external;
+
     ////////////////// VIEW FUNCTIONS ////////////////////
 
     /// @notice Returns the tax configuration for this token
@@ -74,11 +85,6 @@ interface ILivoToken is IERC20 {
     /// @notice Address who can accept ownership of the token
     /// @dev It can be address(0) if no owner is proposed
     function proposedOwner() external view returns (address);
-
-    /// @notice Returns the underlying fee receiver addresses and their share in basis points
-    /// @dev Sourced from the master fee handler's per-token config: returns every current
-    ///      recipient (direct + claimable) with their BPS share. Sum of shares is always 10_000.
-    function getFeeReceivers() external view returns (address[] memory receivers, uint256[] memory sharesBps);
 
     /// @notice Returns the maximum amount of tokens `buyer` can purchase right now on the bonding curve.
     /// @dev Sniper-protected variants enforce per-tx and per-wallet caps during the protection window;

--- a/src/interfaces/ILivoToken.sol
+++ b/src/interfaces/ILivoToken.sol
@@ -11,11 +11,6 @@ interface ILivoToken is IERC20 {
     event NewOwnerProposed(address owner, address proposedOwner, address caller);
     event OwnershipTransferred(address newOwner);
 
-    /// @notice Emitted by `setFeeHandler`. Lets the indexer rotate `TokenFeeData.feeHandler`,
-    ///         rewrite the per-token FeeSplitterShare row when this token is in direct-handler
-    ///         mode, and recompute `isDirectFeeHandlerEOA`.
-    event FeeHandlerChanged(address oldFeeHandler, address newFeeHandler);
-
     /// @notice Shared initialization parameters for Livo token clones
     struct InitializeParams {
         string name;
@@ -53,12 +48,6 @@ interface ILivoToken is IERC20 {
 
     /// @notice Allows the current owner to permanently renounce ownership
     function renounceOwnership() external;
-
-    /// @notice Rotates the fee handler address. Auth: current `owner` OR the launchpad owner.
-    /// @dev    Primary use case: rotate the single direct receiver of a V2-taxable token deployed
-    ///         via the direct-handler path. Pointing back at the master fee handler when the token
-    ///         was never registered there will brick swapbacks — admin's responsibility.
-    function setFeeHandler(address newFeeHandler) external;
 
     ////////////////// VIEW FUNCTIONS ////////////////////
 

--- a/src/interfaces/ILivoToken.sol
+++ b/src/interfaces/ILivoToken.sol
@@ -10,6 +10,7 @@ interface ILivoToken is IERC20 {
     event Graduated();
     event NewOwnerProposed(address owner, address proposedOwner, address caller);
     event OwnershipTransferred(address newOwner);
+    event RouteFees(address feeHandler, uint256 amount);
 
     /// @notice Shared initialization parameters for Livo token clones
     struct InitializeParams {

--- a/src/tokens/LivoTaxableToken.sol
+++ b/src/tokens/LivoTaxableToken.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.28;
 import {LivoToken} from "src/tokens/LivoToken.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {ILivoTaxableToken, TaxConfigInit} from "src/interfaces/ILivoTaxableToken.sol";
-import {ILivoMasterFeeHandler} from "src/interfaces/ILivoMasterFeeHandler.sol";
 import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -76,8 +75,9 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
     ///      (1) Self-token rescue is disallowed — the caller must NEVER be able to siphon accrued
     ///          tax balance ahead of a swap-back.
     ///      (2) ETH stuck in the contract is treated as un-routed fees and pushed back through
-    ///          `feeHandler.depositFees` so it lands on the configured fee receivers, never on
-    ///          the caller. Preserves the project's pull-over-push invariant for ETH.
+    ///          `_accrueFees` (plain ETH transfer to the fee handler, attributed via `msg.sender`)
+    ///          so it lands on the configured fee receivers, never on the caller. Preserves the
+    ///          project's pull-over-push invariant for ETH.
     /// @dev The launchpad owner is included so the protocol admin can sweep stuck balances on
     ///      factory-deployed V2 tokens, where `owner == address(0)` makes the token-owner path
     ///      unreachable. The destination is unchanged regardless of caller: ETH → fee handler,
@@ -88,11 +88,8 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
 
         if (token == address(0)) {
-            uint256 ethBalance = address(this).balance;
-            if (ethBalance > 0) {
-                // deposit fees to the token account in the master fee handler
-                ILivoMasterFeeHandler(feeHandler).depositFees{value: ethBalance}(address(this));
-            }
+            // route any stuck ETH back through the fee handler under this token's accounting
+            _accrueFees(address(this).balance);
         } else if (token == address(this)) {
             // disallow rescuing the token's own balance to prevent siphoning accrued taxes
             revert CannotRescueSelfToken();

--- a/src/tokens/LivoTaxableToken.sol
+++ b/src/tokens/LivoTaxableToken.sol
@@ -21,12 +21,10 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
 
     //////////////////////// potentially immutable //////////////////
 
-    /// @notice Buy tax rate in basis points. Set during initialization; the owner can lower it later
-    ///         via `setTaxBps` (decrease-only — increases revert).
+    /// @notice Buy tax in basis points. Owner can lower it via `setTaxBps` (decrease-only).
     uint16 public buyTaxBps;
 
-    /// @notice Sell tax rate in basis points. Set during initialization; the owner can lower it later
-    ///         via `setTaxBps` (decrease-only — increases revert).
+    /// @notice Sell tax in basis points. Owner can lower it via `setTaxBps` (decrease-only).
     uint16 public sellTaxBps;
 
     /// @notice Duration in seconds after graduation during which taxes apply (set during initialization, cannot be changed)
@@ -42,9 +40,8 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
     /// @notice Emitted once during init with the dev-supplied tax config.
     event LivoTaxableTokenInitialized(uint16 buyTaxBps, uint16 sellTaxBps, uint40 taxDurationSeconds);
 
-    /// @notice Emitted whenever `setTaxBps` successfully updates the buy/sell tax rates. Only the
-    ///         new values are carried; indexers can resolve old values from the prior
-    ///         `LivoTaxableTokenInitialized` event or the most recent prior `TaxBpsUpdated`.
+    /// @notice Emitted on each successful `setTaxBps`. Old values are recoverable from the prior
+    ///         `LivoTaxableTokenInitialized` or `TaxBpsUpdated`.
     event TaxBpsUpdated(uint16 newBuyTaxBps, uint16 newSellTaxBps);
 
     //////////////////////// Errors //////////////////////
@@ -70,45 +67,31 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
         emit Graduated();
     }
 
-    /// @notice Allows the token owner OR the launchpad owner to rescue stuck balances.
-    /// @dev Two restrictions:
-    ///      (1) Self-token rescue is disallowed — the caller must NEVER be able to siphon accrued
-    ///          tax balance ahead of a swap-back.
-    ///      (2) ETH stuck in the contract is treated as un-routed fees and pushed back through
-    ///          `_accrueFees` (plain ETH transfer to the fee handler, attributed via `msg.sender`)
-    ///          so it lands on the configured fee receivers, never on the caller. Preserves the
-    ///          project's pull-over-push invariant for ETH.
-    /// @dev The launchpad owner is included so the protocol admin can sweep stuck balances on
-    ///      factory-deployed V2 tokens, where `owner == address(0)` makes the token-owner path
-    ///      unreachable. The destination is unchanged regardless of caller: ETH → fee handler,
-    ///      ERC20s → `owner` (which may be `address(0)`, in which case the transfer reverts —
-    ///      acceptable, as a stuck-balance rescue with no recipient is a no-op anyway).
+    /// @notice Rescues stuck balances. Callable by token owner OR launchpad owner (the latter so
+    ///         admins can sweep on factory-deployed tokens where `owner == address(0)`).
+    /// @dev Stuck ETH is pushed through `_accrueFees` so it lands on the fee receivers, never on
+    ///      the caller — preserves the pull-over-push invariant. Self-token rescue is disallowed
+    ///      to block siphoning accrued tax balance ahead of a swap-back. ERC20s go to `owner`
+    ///      (reverts if `address(0)`, which is acceptable).
     /// @param token Token to rescue. Pass `address(0)` for ETH.
     function rescueTokens(address token) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
 
         if (token == address(0)) {
-            // route any stuck ETH back through the fee handler under this token's accounting
             _accrueFees(address(this).balance);
         } else if (token == address(this)) {
-            // disallow rescuing the token's own balance to prevent siphoning accrued taxes
             revert CannotRescueSelfToken();
         } else {
             IERC20(token).safeTransfer(owner, IERC20(token).balanceOf(address(this)));
         }
     }
 
-    /// @notice Updates `buyTaxBps` and/or `sellTaxBps`. Today this is decrease-only — any attempt
-    ///         to raise either rate reverts with `TaxBpsCanOnlyDecrease`. Passing a value equal to
-    ///         the current one is allowed (no-op for that side). `taxDurationSeconds` and
-    ///         `graduationTimestamp` are untouched.
-    /// @dev The function name is intentionally generic (`setTaxBps`) even though the body enforces
-    ///      a narrower decrease-only rule. This keeps the ABI stable if the policy is ever relaxed.
-    /// @dev Callable by the token owner OR the launchpad owner — same dual-auth pattern as
-    ///      `swapBack` / `rescueTokens`. On factory-deployed tokens (`owner == address(0)`) only
-    ///      the launchpad-owner branch is reachable, which is intentional.
-    /// @param newBuyTaxBps New buy tax rate in basis points. Must be `<= buyTaxBps`.
-    /// @param newSellTaxBps New sell tax rate in basis points. Must be `<= sellTaxBps`.
+    /// @notice Updates `buyTaxBps` / `sellTaxBps`. Decrease-only — increases revert with
+    ///         `TaxBpsCanOnlyDecrease`. Equal values are a no-op. `taxDurationSeconds` and
+    ///         `graduationTimestamp` are untouched. Callable by token owner OR launchpad owner.
+    /// @dev Name is generic to keep the ABI stable if the decrease-only rule is later relaxed.
+    /// @param newBuyTaxBps Must be `<= buyTaxBps`.
+    /// @param newSellTaxBps Must be `<= sellTaxBps`.
     function setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
         require(newBuyTaxBps <= buyTaxBps && newSellTaxBps <= sellTaxBps, TaxBpsCanOnlyDecrease());

--- a/src/tokens/LivoTaxableToken.sol
+++ b/src/tokens/LivoTaxableToken.sol
@@ -22,10 +22,12 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
 
     //////////////////////// potentially immutable //////////////////
 
-    /// @notice Buy tax rate in basis points (set during initialization, cannot be changed)
+    /// @notice Buy tax rate in basis points. Set during initialization; the owner can lower it later
+    ///         via `setTaxBps` (decrease-only — increases revert).
     uint16 public buyTaxBps;
 
-    /// @notice Sell tax rate in basis points (set during initialization, cannot be changed)
+    /// @notice Sell tax rate in basis points. Set during initialization; the owner can lower it later
+    ///         via `setTaxBps` (decrease-only — increases revert).
     uint16 public sellTaxBps;
 
     /// @notice Duration in seconds after graduation during which taxes apply (set during initialization, cannot be changed)
@@ -41,10 +43,16 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
     /// @notice Emitted once during init with the dev-supplied tax config.
     event LivoTaxableTokenInitialized(uint16 buyTaxBps, uint16 sellTaxBps, uint40 taxDurationSeconds);
 
+    /// @notice Emitted whenever `setTaxBps` successfully updates the buy/sell tax rates. Only the
+    ///         new values are carried; indexers can resolve old values from the prior
+    ///         `LivoTaxableTokenInitialized` event or the most recent prior `TaxBpsUpdated`.
+    event TaxBpsUpdated(uint16 newBuyTaxBps, uint16 newSellTaxBps);
+
     //////////////////////// Errors //////////////////////
 
     error NotTokenOwner();
     error CannotRescueSelfToken();
+    error TaxBpsCanOnlyDecrease();
 
     //////////////////////////////////////////////////////
 
@@ -91,6 +99,27 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
         } else {
             IERC20(token).safeTransfer(owner, IERC20(token).balanceOf(address(this)));
         }
+    }
+
+    /// @notice Updates `buyTaxBps` and/or `sellTaxBps`. Today this is decrease-only — any attempt
+    ///         to raise either rate reverts with `TaxBpsCanOnlyDecrease`. Passing a value equal to
+    ///         the current one is allowed (no-op for that side). `taxDurationSeconds` and
+    ///         `graduationTimestamp` are untouched.
+    /// @dev The function name is intentionally generic (`setTaxBps`) even though the body enforces
+    ///      a narrower decrease-only rule. This keeps the ABI stable if the policy is ever relaxed.
+    /// @dev Callable by the token owner OR the launchpad owner — same dual-auth pattern as
+    ///      `swapBack` / `rescueTokens`. On factory-deployed tokens (`owner == address(0)`) only
+    ///      the launchpad-owner branch is reachable, which is intentional.
+    /// @param newBuyTaxBps New buy tax rate in basis points. Must be `<= buyTaxBps`.
+    /// @param newSellTaxBps New sell tax rate in basis points. Must be `<= sellTaxBps`.
+    function setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps) external {
+        require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
+        require(newBuyTaxBps <= buyTaxBps && newSellTaxBps <= sellTaxBps, TaxBpsCanOnlyDecrease());
+
+        emit TaxBpsUpdated(newBuyTaxBps, newSellTaxBps);
+
+        buyTaxBps = newBuyTaxBps;
+        sellTaxBps = newSellTaxBps;
     }
 
     //////////////////////// VIEW FUNCTIONS //////////////////////

--- a/src/tokens/LivoTaxableTokenUniV2.sol
+++ b/src/tokens/LivoTaxableTokenUniV2.sol
@@ -24,9 +24,12 @@ import {DeploymentAddressesMainnet as DeploymentAddresses} from "src/config/Depl
 ///      would otherwise never accrue enough fresh tax to cross it, since no new tax accrues once
 ///      the window expires. Recursion is guarded by `_inSwap`: when the router pulls tokens from
 ///      this contract during the swap, our `_update` short-circuits to a plain transfer.
-///      At most one swap-back per block is allowed: `_swapBack` silently returns when
-///      `block.number <= lastSwapbackBlock`, so any second (or further) call in the same block
-///      — auto or manual — is a no-op.
+///      At most `MAX_SWAPBACKS_PER_BLOCK` swap-backs per block are allowed: `_swapBack` resets
+///      `swapbacksThisBlock` to zero when `block.number > lastSwapbackBlock`, increments it on
+///      each successful swap, and silently returns when the counter hits the cap — so any further
+///      call in the same block (auto or manual) is a no-op. This counter shape mirrors the
+///      reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`, which passes Go+'s
+///      "trading cooldown" heuristic.
 ///      A permissioned `swapBack(amountOutMinWei)` lets the owner trigger a slippage-bounded swap
 ///      via a private mempool to avoid sandwiches; on factory-deployed tokens the owner is
 ///      `address(0)`, so this entry point is reachable only via the launchpad owner, and the
@@ -46,6 +49,12 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         sells while keeping per-swap price-impact bounded for the common case.
     uint256 public constant SWAP_THRESHOLD = TOTAL_SUPPLY / 2000;
 
+    /// @notice Maximum number of swap-backs allowed per block. Further calls in the same block
+    ///         silently no-op. Picked low enough that a single block's swap-back activity stays
+    ///         bounded, high enough that two whales selling in the same block both get their
+    ///         tax routed without one having to wait a block.
+    uint8 public constant MAX_SWAPBACKS_PER_BLOCK = 2;
+
     /////////////////////////// pure storage ///////////////////////
 
     /// @dev Re-entrancy guard for the swap-back path. When true, `_update` short-circuits the
@@ -54,11 +63,17 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     bool internal transient _inSwap;
 
     /// @notice `block.number` of the most recent successful `_swapBack`. Zero until the first
-    ///         swapback runs. `_swapBack` itself gates on `block.number > lastSwapbackBlock` and
-    ///         silently returns otherwise, so the contract performs at most one swap-back per
-    ///         block (both auto and manual paths). uint48 packs into the parent
-    ///         `LivoTaxableToken` slot alongside `graduationTimestamp`.
+    ///         swapback runs. Used together with `swapbacksThisBlock` to enforce the per-block
+    ///         cap: when `block.number > lastSwapbackBlock`, the counter resets to zero. uint48
+    ///         packs into the parent `LivoTaxableToken` slot alongside `graduationTimestamp`.
     uint48 public lastSwapbackBlock;
+
+    /// @notice Count of successful `_swapBack` calls that have already settled in
+    ///         `lastSwapbackBlock`. Reset to zero on the first swap-back of a new block and
+    ///         incremented after each successful swap. Once it reaches `MAX_SWAPBACKS_PER_BLOCK`,
+    ///         further calls in the same block silently no-op. uint8 packs into the parent slot
+    ///         alongside `lastSwapbackBlock` and `graduationTimestamp`.
+    uint8 public swapbacksThisBlock;
 
     //////////////////////// Events //////////////////////
 
@@ -116,9 +131,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///      inside `_update` remains the primary path regardless of caller identity. Proceeds are
     ///      forwarded to the fee handler (not the caller), so widening the caller set has no
     ///      asset-routing impact.
-    /// @dev If a swap-back has already settled in the current block, `_swapBack` silently
-    ///      no-ops — the call succeeds but emits no `CreatorTaxSwapback` event. Callers gating
-    ///      on the event still get a clean signal; callers expecting a revert do not.
+    /// @dev If `MAX_SWAPBACKS_PER_BLOCK` swap-backs have already settled in the current block,
+    ///      `_swapBack` silently no-ops — the call succeeds but emits no `CreatorTaxSwapback`
+    ///      event. Callers gating on the event still get a clean signal; callers expecting a
+    ///      revert do not.
     function swapBack(uint256 swapAmount, uint256 amountOutMinWei) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
         _swapBack(swapAmount, amountOutMinWei);
@@ -135,9 +151,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         when `balance >= SWAP_THRESHOLD`, OR — after the tax window expires — when any
     ///         non-zero balance remains, so a sub-threshold residual gets drained on the next sell
     ///         instead of stranding forever (no new tax accrues post-window to push it across).
-    ///         `_swapBack` itself enforces the at-most-one-per-block guarantee (silent no-op on
-    ///         repeat); this outer branch deliberately does NOT reference `block.number` so static
-    ///         analyzers don't mistake the per-block swap-back cap for a per-user trading cooldown.
+    ///         `_swapBack` itself enforces the at-most-`MAX_SWAPBACKS_PER_BLOCK`-per-block
+    ///         guarantee via a counter (silent no-op on overflow); this outer branch deliberately
+    ///         does NOT reference `block.number` so static analyzers don't mistake the per-block
+    ///         swap-back cap for a per-user trading cooldown.
     ///         Any excess stays on the contract and is drained on the next qualifying sell.
     ///      4. If we're in the post-graduation tax window AND the transfer touches the pair AND
     ///         the source is not the graduator (which moves the initial liquidity), divert
@@ -172,9 +189,11 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         // produces a `_update(graduator, pair, ...)` while the pair still has zero reserves, so
         // firing `_swapBack` against it would revert the entire graduation tx. Anyone could grief
         // graduation by pre-funding `address(this)` with `>= SWAP_THRESHOLD` tokens before it.
-        // The per-block at-most-once gate lives inside `_swapBack` (silent return) so this outer
-        // sell-branch condition references no `block.number` — static heuristics (e.g. Go+) flag
-        // any `block.number` read in a transfer-hook sell branch as a trading cooldown.
+        // The per-block cap (at most `MAX_SWAPBACKS_PER_BLOCK`) lives inside `_swapBack` as a
+        // counter (silent no-op on overflow), so this outer sell-branch condition references no
+        // `block.number` — static heuristics (e.g. Go+) flag any `block.number` read in a
+        // transfer-hook sell branch as a trading cooldown. Counter-reset-on-new-block matches the
+        // shape of the reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`.
         if (isSell && from != graduator) {
             uint256 contractBalance = balanceOf(address(this));
             if (contractBalance >= SWAP_THRESHOLD) {
@@ -219,16 +238,23 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     /// @dev `address(this).balance` is forwarded in full (not just the swap output): any ETH that
     ///      may have arrived through `receive()` between swap-backs is treated as un-routed fees
     ///      and routed through the same path. Avoids ETH ever sitting idle in the contract.
-    /// @dev Enforces at most one swap-back per block via a silent early-return when a swap-back
-    ///      has already settled in this block. The auto path (from `_update`) and the manual
-    ///      `swapBack` entry point both go through this helper, so both same-block-repeat the
-    ///      same way: tx succeeds, no `CreatorTaxSwapback` event, no balance change. The gate
-    ///      lives here (not in the outer sell branch of `_update`) to keep `block.number` out
-    ///      of the transfer hook's gating condition — static analyzers (e.g. Go+) flag any
-    ///      such read as a per-user trading cooldown.
+    /// @dev Enforces at most `MAX_SWAPBACKS_PER_BLOCK` swap-backs per block via a counter that
+    ///      resets to zero on the first call of each new block and increments after each
+    ///      successful swap; once the counter hits the cap, further calls in the same block
+    ///      silently return. The auto path (from `_update`) and the manual `swapBack` entry
+    ///      point both go through this helper, so both same-block-overflow the same way: tx
+    ///      succeeds, no `CreatorTaxSwapback` event, no balance change. The gate lives here
+    ///      (not in the outer sell branch of `_update`) to keep `block.number` out of the
+    ///      transfer hook's gating condition — static analyzers (e.g. Go+) flag any such read
+    ///      as a per-user trading cooldown. The counter-reset-on-new-block shape mirrors the
+    ///      reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`.
     function _swapBack(uint256 tokenAmount, uint256 amountOutMinWei) internal {
         if (tokenAmount == 0) return;
-        if (block.number <= uint256(lastSwapbackBlock)) return;
+
+        if (block.number > uint256(lastSwapbackBlock)) {
+            swapbacksThisBlock = 0;
+        }
+        if (swapbacksThisBlock >= MAX_SWAPBACKS_PER_BLOCK) return;
 
         _inSwap = true;
 
@@ -241,6 +267,7 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         );
 
         _inSwap = false;
+        swapbacksThisBlock++;
         lastSwapbackBlock = uint48(block.number);
 
         uint256 ethBalance = address(this).balance;

--- a/src/tokens/LivoTaxableTokenUniV2.sol
+++ b/src/tokens/LivoTaxableTokenUniV2.sol
@@ -24,12 +24,13 @@ import {DeploymentAddressesMainnet as DeploymentAddresses} from "src/config/Depl
 ///      would otherwise never accrue enough fresh tax to cross it, since no new tax accrues once
 ///      the window expires. Recursion is guarded by `_inSwap`: when the router pulls tokens from
 ///      this contract during the swap, our `_update` short-circuits to a plain transfer.
-///      At most one swap-back per block is allowed: the gate `block.number > lastSwapbackBlock`
-///      silently skips the auto-trigger for any second (or further) sell that settles in the
-///      same block as the prior swap-back.
+///      At most one swap-back per block is allowed: `_swapBack` silently returns when
+///      `block.number <= lastSwapbackBlock`, so any second (or further) call in the same block
+///      — auto or manual — is a no-op.
 ///      A permissioned `swapBack(amountOutMinWei)` lets the owner trigger a slippage-bounded swap
 ///      via a private mempool to avoid sandwiches; on factory-deployed tokens the owner is
-///      `address(0)`, so this entry point always reverts and the auto-trigger is the live path.
+///      `address(0)`, so this entry point is reachable only via the launchpad owner, and the
+///      auto-trigger remains the live path.
 contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///////////////////////////////// uniswap v2 related /////////////////////////////////////////
     // NB : THESE ARE HARDCODED FOR MAINNET TO SAVE GAS
@@ -53,10 +54,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     bool internal transient _inSwap;
 
     /// @notice `block.number` of the most recent successful `_swapBack`. Zero until the first
-    ///         swapback runs. The auto-trigger and the manual `swapBack` both gate on
-    ///         `block.number > lastSwapbackBlock` so the contract performs at most one
-    ///         swap-back per block. uint48 packs into the parent `LivoTaxableToken` slot
-    ///         alongside `graduationTimestamp`.
+    ///         swapback runs. `_swapBack` itself gates on `block.number > lastSwapbackBlock` and
+    ///         silently returns otherwise, so the contract performs at most one swap-back per
+    ///         block (both auto and manual paths). uint48 packs into the parent
+    ///         `LivoTaxableToken` slot alongside `graduationTimestamp`.
     uint48 public lastSwapbackBlock;
 
     //////////////////////// Events //////////////////////
@@ -67,13 +68,6 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         i.e. the tax actually accrued to the creator (and any direct receivers) for the
     ///         swap window covered by this back-swap.
     event CreatorTaxSwapback(uint256 tokenAmountIn, uint256 ethAmount);
-
-    //////////////////////// Errors //////////////////////
-
-    /// @notice Thrown by manual `swapBack` when a swap-back has already settled in the current
-    ///         block. The auto-trigger in `_update` does NOT revert on this condition — it
-    ///         silently skips the swap so the second sell in the block keeps settling.
-    error SwapbackAlreadyInThisBlock();
 
     //////////////////////////////////////////////////////
 
@@ -122,6 +116,9 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///      inside `_update` remains the primary path regardless of caller identity. Proceeds are
     ///      forwarded to the fee handler (not the caller), so widening the caller set has no
     ///      asset-routing impact.
+    /// @dev If a swap-back has already settled in the current block, `_swapBack` silently
+    ///      no-ops — the call succeeds but emits no `CreatorTaxSwapback` event. Callers gating
+    ///      on the event still get a clean signal; callers expecting a revert do not.
     function swapBack(uint256 swapAmount, uint256 amountOutMinWei) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
         _swapBack(swapAmount, amountOutMinWei);
@@ -138,9 +135,9 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         when `balance >= SWAP_THRESHOLD`, OR — after the tax window expires — when any
     ///         non-zero balance remains, so a sub-threshold residual gets drained on the next sell
     ///         instead of stranding forever (no new tax accrues post-window to push it across).
-    ///         Both branches are additionally gated on `block.number > lastSwapbackBlock` so the
-    ///         contract performs at most one swap-back per block — further same-block sells
-    ///         silently skip the auto-trigger.
+    ///         `_swapBack` itself enforces the at-most-one-per-block guarantee (silent no-op on
+    ///         repeat); this outer branch deliberately does NOT reference `block.number` so static
+    ///         analyzers don't mistake the per-block swap-back cap for a per-user trading cooldown.
     ///         Any excess stays on the contract and is drained on the next qualifying sell.
     ///      4. If we're in the post-graduation tax window AND the transfer touches the pair AND
     ///         the source is not the graduator (which moves the initial liquidity), divert
@@ -175,10 +172,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         // produces a `_update(graduator, pair, ...)` while the pair still has zero reserves, so
         // firing `_swapBack` against it would revert the entire graduation tx. Anyone could grief
         // graduation by pre-funding `address(this)` with `>= SWAP_THRESHOLD` tokens before it.
-        // Per-block cap pre-gates both auto-trigger branches. `lastSwapbackBlock` shares the
-        // parent's `graduationTimestamp` slot, so this SLOAD also pre-warms the slot read by
-        // the tax-window branch below.
-        if (isSell && from != graduator && block.number > uint256(lastSwapbackBlock)) {
+        // The per-block at-most-once gate lives inside `_swapBack` (silent return) so this outer
+        // sell-branch condition references no `block.number` — static heuristics (e.g. Go+) flag
+        // any `block.number` read in a transfer-hook sell branch as a trading cooldown.
+        if (isSell && from != graduator) {
             uint256 contractBalance = balanceOf(address(this));
             if (contractBalance >= SWAP_THRESHOLD) {
                 uint256 swapAmount = contractBalance > 2 * SWAP_THRESHOLD ? 2 * SWAP_THRESHOLD : contractBalance;
@@ -222,13 +219,16 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     /// @dev `address(this).balance` is forwarded in full (not just the swap output): any ETH that
     ///      may have arrived through `receive()` between swap-backs is treated as un-routed fees
     ///      and routed through the same path. Avoids ETH ever sitting idle in the contract.
-    /// @dev Enforces at most one swap-back per block. Reverts with `SwapbackAlreadyInThisBlock`
-    ///      if a swap-back has already settled in this block — `_update` pre-checks the same
-    ///      condition and skips the auto-trigger, so in practice only the manual `swapBack`
-    ///      entry point ever surfaces this revert.
+    /// @dev Enforces at most one swap-back per block via a silent early-return when a swap-back
+    ///      has already settled in this block. The auto path (from `_update`) and the manual
+    ///      `swapBack` entry point both go through this helper, so both same-block-repeat the
+    ///      same way: tx succeeds, no `CreatorTaxSwapback` event, no balance change. The gate
+    ///      lives here (not in the outer sell branch of `_update`) to keep `block.number` out
+    ///      of the transfer hook's gating condition — static analyzers (e.g. Go+) flag any
+    ///      such read as a per-user trading cooldown.
     function _swapBack(uint256 tokenAmount, uint256 amountOutMinWei) internal {
         if (tokenAmount == 0) return;
-        require(block.number > uint256(lastSwapbackBlock), SwapbackAlreadyInThisBlock());
+        if (block.number <= uint256(lastSwapbackBlock)) return;
 
         _inSwap = true;
 

--- a/src/tokens/LivoTaxableTokenUniV2.sol
+++ b/src/tokens/LivoTaxableTokenUniV2.sol
@@ -18,22 +18,14 @@ import {DeploymentAddressesMainnet as DeploymentAddresses} from "src/config/Depl
 ///         the same `accrueFees` path that V4 uses.
 /// @dev Auto-swap-back fires inside `_update` on sells once the contract holds at least
 ///      `SWAP_THRESHOLD` tokens — or, after the tax window expires, any non-zero residual — and
-///      never swaps more than `2 * SWAP_THRESHOLD` per sell so the price impact a single trader
-///      observes stays bounded; any excess balance carries to the next qualifying sell. The
-///      post-window drain handles the case where leftover tax tokens stuck below `SWAP_THRESHOLD`
-///      would otherwise never accrue enough fresh tax to cross it, since no new tax accrues once
-///      the window expires. Recursion is guarded by `_inSwap`: when the router pulls tokens from
-///      this contract during the swap, our `_update` short-circuits to a plain transfer.
-///      At most `MAX_SWAPBACKS_PER_BLOCK` swap-backs per block are allowed: `_swapBack` resets
-///      `swapbacksThisBlock` to zero when `block.number > lastSwapbackBlock`, increments it on
-///      each successful swap, and silently returns when the counter hits the cap — so any further
-///      call in the same block (auto or manual) is a no-op. This counter shape mirrors the
-///      reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`, which passes Go+'s
-///      "trading cooldown" heuristic.
-///      A permissioned `swapBack(amountOutMinWei)` lets the owner trigger a slippage-bounded swap
-///      via a private mempool to avoid sandwiches; on factory-deployed tokens the owner is
-///      `address(0)`, so this entry point is reachable only via the launchpad owner, and the
-///      auto-trigger remains the live path.
+///      never swaps more than `2 * SWAP_THRESHOLD` per sell so the per-sell price impact stays
+///      bounded; excess carries to the next qualifying sell. Recursion is guarded by `_inSwap`.
+///      At most `MAX_SWAPBACKS_PER_BLOCK` swap-backs per block: the counter resets on a new
+///      block and silent-no-ops on overflow. Counter shape mirrors a reference token that passes
+///      Go+'s "trading cooldown" heuristic; see `_swapBack`.
+///      `swapBack(amountOutMinWei)` lets the owner trigger a slippage-bounded swap via a private
+///      mempool. Factory-deployed tokens have `owner == address(0)`, so this entry point is
+///      reachable only via the launchpad owner; the auto-trigger remains the live path.
 contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///////////////////////////////// uniswap v2 related /////////////////////////////////////////
     // NB : THESE ARE HARDCODED FOR MAINNET TO SAVE GAS
@@ -49,10 +41,8 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         sells while keeping per-swap price-impact bounded for the common case.
     uint256 public constant SWAP_THRESHOLD = TOTAL_SUPPLY / 2000;
 
-    /// @notice Maximum number of swap-backs allowed per block. Further calls in the same block
-    ///         silently no-op. Picked low enough that a single block's swap-back activity stays
-    ///         bounded, high enough that two whales selling in the same block both get their
-    ///         tax routed without one having to wait a block.
+    /// @notice Max swap-backs per block. Further same-block calls silently no-op. Picked so two
+    ///         whales selling in the same block both get their tax routed.
     uint8 public constant MAX_SWAPBACKS_PER_BLOCK = 2;
 
     /////////////////////////// pure storage ///////////////////////
@@ -62,26 +52,19 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///      ERC20 transfer. Lives in transient storage — auto-clears at end of tx, no SSTORE cost.
     bool internal transient _inSwap;
 
-    /// @notice `block.number` of the most recent successful `_swapBack`. Zero until the first
-    ///         swapback runs. Used together with `swapbacksThisBlock` to enforce the per-block
-    ///         cap: when `block.number > lastSwapbackBlock`, the counter resets to zero. uint48
-    ///         packs into the parent `LivoTaxableToken` slot alongside `graduationTimestamp`.
+    /// @notice `block.number` of the most recent successful `_swapBack`; zero until the first.
+    ///         Paired with `swapbacksThisBlock` for the per-block cap. uint48 packs into the
+    ///         parent `LivoTaxableToken` slot alongside `graduationTimestamp`.
     uint48 public lastSwapbackBlock;
 
-    /// @notice Count of successful `_swapBack` calls that have already settled in
-    ///         `lastSwapbackBlock`. Reset to zero on the first swap-back of a new block and
-    ///         incremented after each successful swap. Once it reaches `MAX_SWAPBACKS_PER_BLOCK`,
-    ///         further calls in the same block silently no-op. uint8 packs into the parent slot
-    ///         alongside `lastSwapbackBlock` and `graduationTimestamp`.
+    /// @notice Swap-backs already settled in `lastSwapbackBlock`. Resets on the first swap-back
+    ///         of a new block; at `MAX_SWAPBACKS_PER_BLOCK` further same-block calls silent-no-op.
     uint8 public swapbacksThisBlock;
 
     //////////////////////// Events //////////////////////
 
-    /// @notice Emitted whenever the contract auto- or manually-swaps accumulated tax tokens to ETH
-    ///         and forwards the proceeds to the master fee handler. `ethAmount` is the ETH
-    ///         pushed via `_accrueFees` (plain ETH transfer to the handler) for this swap-back,
-    ///         i.e. the tax actually accrued to the creator (and any direct receivers) for the
-    ///         swap window covered by this back-swap.
+    /// @notice Emitted on each successful swap-back. `ethAmount` is the ETH pushed via
+    ///         `_accrueFees` (the contract's full balance), i.e. the tax accrued for this window.
     event CreatorTaxSwapback(uint256 tokenAmountIn, uint256 ethAmount);
 
     //////////////////////////////////////////////////////
@@ -116,25 +99,13 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     }
 
     /// @notice Manually triggers a swap of `swapAmount` tax tokens for ETH and forwards the
-    ///         proceeds to the master fee handler. Callable by the token owner OR the launchpad
-    ///         owner.
-    /// @param swapAmount Amount of tax tokens to swap. The caller is expected to size this against
-    ///        `balanceOf(address(this))` and their own price-impact budget; the auto path's
-    ///        `2 * SWAP_THRESHOLD` cap is not enforced here, so a private-mempool caller can drain
-    ///        a larger residual in one shot. The router will revert if `swapAmount` exceeds the
-    ///        contract's balance.
-    /// @param amountOutMinWei Minimum ETH (in wei) the swap must yield. The caller is expected to
-    ///        compute this from `router.getAmountsOut(...)` plus their own slippage budget; this
-    ///        is the path used to MEV-protect a swap via a private mempool.
-    /// @dev Factory-deployed tokens always have `owner == address(0)`; the launchpad-owner branch
-    ///      is therefore the only reachable manual path on those deployments. The auto-trigger
-    ///      inside `_update` remains the primary path regardless of caller identity. Proceeds are
-    ///      forwarded to the fee handler (not the caller), so widening the caller set has no
-    ///      asset-routing impact.
-    /// @dev If `MAX_SWAPBACKS_PER_BLOCK` swap-backs have already settled in the current block,
-    ///      `_swapBack` silently no-ops — the call succeeds but emits no `CreatorTaxSwapback`
-    ///      event. Callers gating on the event still get a clean signal; callers expecting a
-    ///      revert do not.
+    ///         proceeds to the fee handler. Callable by the token owner OR the launchpad owner;
+    ///         primary use is MEV-protected execution via a private mempool.
+    /// @param swapAmount Amount to swap. The auto path's `2 * SWAP_THRESHOLD` cap is NOT enforced
+    ///        here so a private-mempool caller can drain a larger residual in one shot. The router
+    ///        reverts if `swapAmount` exceeds the contract's balance.
+    /// @param amountOutMinWei Minimum ETH the swap must yield. Caller's slippage budget.
+    /// @dev If the per-block cap is hit, `_swapBack` silently no-ops (no event, no revert).
     function swapBack(uint256 swapAmount, uint256 amountOutMinWei) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
         _swapBack(swapAmount, amountOutMinWei);
@@ -142,27 +113,20 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
 
     ////////////////////// INTERNAL FUNCTIONS //////////////////////
 
-    /// @dev Intrinsic taxation hook. Order of operations:
-    ///      1. If `_inSwap` (we're inside `_swapBack`), bypass everything — the router's
-    ///         `transferFrom(this, pair, ...)` must be a plain transfer, otherwise we recurse.
-    ///      2. Apply the inherited pre-graduation gate.
-    ///      3. On a sell with accumulated balance, fire `_swapBack(amount, 0)` capped at
-    ///         `2 * SWAP_THRESHOLD` to bound the per-sell price impact (auto path). Trigger fires
-    ///         when `balance >= SWAP_THRESHOLD`, OR — after the tax window expires — when any
-    ///         non-zero balance remains, so a sub-threshold residual gets drained on the next sell
-    ///         instead of stranding forever (no new tax accrues post-window to push it across).
-    ///         `_swapBack` itself enforces the at-most-`MAX_SWAPBACKS_PER_BLOCK`-per-block
-    ///         guarantee via a counter (silent no-op on overflow); this outer branch deliberately
-    ///         does NOT reference `block.number` so static analyzers don't mistake the per-block
-    ///         swap-back cap for a per-user trading cooldown.
-    ///         Any excess stays on the contract and is drained on the next qualifying sell.
-    ///      4. If we're in the post-graduation tax window AND the transfer touches the pair AND
-    ///         the source is not the graduator (which moves the initial liquidity), divert
+    /// @dev Intrinsic taxation hook. Order:
+    ///      1. If `_inSwap`, bypass — the router's `transferFrom(this, pair, ...)` must be a plain
+    ///         transfer, otherwise we recurse.
+    ///      2. Inherited pre-graduation gate.
+    ///      3. On a sell with accumulated balance, fire `_swapBack` capped at `2 * SWAP_THRESHOLD`.
+    ///         Trigger fires at `balance >= SWAP_THRESHOLD`, OR — after the tax window expires —
+    ///         on any non-zero residual (no fresh tax can push a sub-threshold balance across).
+    ///         The per-block cap lives inside `_swapBack`; this outer branch deliberately does NOT
+    ///         read `block.number` so static analyzers don't flag a trading cooldown.
+    ///      4. In the tax window, on a pair-touching transfer from a non-graduator source, divert
     ///         `amount * bps / 10_000` to this contract and forward the rest.
-    ///      The graduator exclusion is load-bearing: graduation transfers `markGraduated() →
-    ///      safeTransfer(pair) → router.addLiquidityETH` all run with `to == pair` after
-    ///      `graduationTimestamp` is stamped, so without the exclusion the initial liquidity
-    ///      would be taxed.
+    ///      The graduator exclusion is load-bearing: `markGraduated() → safeTransfer(pair) →
+    ///      addLiquidityETH` runs with `to == pair` AFTER `graduationTimestamp` is stamped, so
+    ///      without it the initial liquidity would be taxed.
     function _update(address from, address to, uint256 amount) internal virtual override {
         if (_inSwap) {
             super._update(from, to, amount);
@@ -182,18 +146,11 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         bool isSell = (to == _pair);
         bool isBuy = (from == _pair);
 
-        // Auto swap-back: only on sells, and only if the contract has enough accumulated tax to
-        // make the swap worthwhile. `from != address(this)` is implied by `_inSwap` already being
-        // false here (the contract only ever transfers tokens during a swap-back).
-        // `from != graduator` is load-bearing: the graduator's initial `addLiquidityETH` call
-        // produces a `_update(graduator, pair, ...)` while the pair still has zero reserves, so
-        // firing `_swapBack` against it would revert the entire graduation tx. Anyone could grief
-        // graduation by pre-funding `address(this)` with `>= SWAP_THRESHOLD` tokens before it.
-        // The per-block cap (at most `MAX_SWAPBACKS_PER_BLOCK`) lives inside `_swapBack` as a
-        // counter (silent no-op on overflow), so this outer sell-branch condition references no
-        // `block.number` — static heuristics (e.g. Go+) flag any `block.number` read in a
-        // transfer-hook sell branch as a trading cooldown. Counter-reset-on-new-block matches the
-        // shape of the reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`.
+        // Auto swap-back on sells. `from != graduator` is load-bearing: the graduator's initial
+        // `addLiquidityETH` triggers `_update(graduator, pair, ...)` while the pair has zero
+        // reserves, so firing `_swapBack` then would revert graduation (and could be griefed by
+        // pre-funding `address(this)`). Per-block cap is enforced inside `_swapBack` to keep
+        // `block.number` out of the transfer hook (Go+ flags such reads as a trading cooldown).
         if (isSell && from != graduator) {
             uint256 contractBalance = balanceOf(address(this));
             if (contractBalance >= SWAP_THRESHOLD) {
@@ -227,27 +184,15 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         super._update(from, to, amount);
     }
 
-    /// @dev Swaps `tokenAmount` of the contract's tax-token balance to ETH on the V2 router and
-    ///      forwards the proceeds to the master fee handler. The `_inSwap` flag short-circuits
-    ///      `_update` for the duration of the swap so the router's `transferFrom(this, pair, ...)`
-    ///      is a plain transfer (no recursive tax, no recursive auto-trigger).
-    /// @dev Callers are responsible for passing a valid `tokenAmount` (≤ contract balance) and
-    ///      for applying any cap (e.g. `2 * SWAP_THRESHOLD` on the auto path). Sourcing the amount
-    ///      from the caller avoids re-reading `balanceOf(address(this))` after `_update` already
-    ///      consulted it.
-    /// @dev `address(this).balance` is forwarded in full (not just the swap output): any ETH that
-    ///      may have arrived through `receive()` between swap-backs is treated as un-routed fees
-    ///      and routed through the same path. Avoids ETH ever sitting idle in the contract.
-    /// @dev Enforces at most `MAX_SWAPBACKS_PER_BLOCK` swap-backs per block via a counter that
-    ///      resets to zero on the first call of each new block and increments after each
-    ///      successful swap; once the counter hits the cap, further calls in the same block
-    ///      silently return. The auto path (from `_update`) and the manual `swapBack` entry
-    ///      point both go through this helper, so both same-block-overflow the same way: tx
-    ///      succeeds, no `CreatorTaxSwapback` event, no balance change. The gate lives here
-    ///      (not in the outer sell branch of `_update`) to keep `block.number` out of the
-    ///      transfer hook's gating condition — static analyzers (e.g. Go+) flag any such read
-    ///      as a per-user trading cooldown. The counter-reset-on-new-block shape mirrors the
-    ///      reference token at `0xbad06a3ca84e4e2b489974d8918b5f7387e6db8e`.
+    /// @dev Swaps `tokenAmount` to ETH on the V2 router and pushes the contract's full ETH
+    ///      balance to the fee handler. `_inSwap` short-circuits `_update` during the router pull
+    ///      so it's a plain transfer (no recursive tax / auto-trigger). Caller must size
+    ///      `tokenAmount` against the balance and any per-sell cap.
+    /// @dev Per-block cap: resets `swapbacksThisBlock` on a new block, increments on success;
+    ///      same-block overflow silently no-ops (tx succeeds, no event, no balance change). Both
+    ///      auto and manual paths go through here. The gate lives in `_swapBack` (not in
+    ///      `_update`'s sell branch) so `block.number` stays out of the transfer hook — Go+ flags
+    ///      such reads as a per-user trading cooldown.
     function _swapBack(uint256 tokenAmount, uint256 amountOutMinWei) internal {
         if (tokenAmount == 0) return;
 
@@ -273,8 +218,6 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         uint256 ethBalance = address(this).balance;
         emit CreatorTaxSwapback(tokenAmount, ethBalance);
 
-        // Plain ETH push: the handler's `receive()` attributes the deposit via `msg.sender`,
-        // so no `address(this)` argument is needed. `_accrueFees` no-ops on zero balance.
         _accrueFees(ethBalance);
     }
 }

--- a/src/tokens/LivoTaxableTokenUniV2.sol
+++ b/src/tokens/LivoTaxableTokenUniV2.sol
@@ -25,6 +25,9 @@ import {DeploymentAddressesMainnet as DeploymentAddresses} from "src/config/Depl
 ///      would otherwise never accrue enough fresh tax to cross it, since no new tax accrues once
 ///      the window expires. Recursion is guarded by `_inSwap`: when the router pulls tokens from
 ///      this contract during the swap, our `_update` short-circuits to a plain transfer.
+///      At most one swap-back per block is allowed: the gate `block.number > lastSwapbackBlock`
+///      silently skips the auto-trigger for any second (or further) sell that settles in the
+///      same block as the prior swap-back.
 ///      A permissioned `swapBack(amountOutMinWei)` lets the owner trigger a slippage-bounded swap
 ///      via a private mempool to avoid sandwiches; on factory-deployed tokens the owner is
 ///      `address(0)`, so this entry point always reverts and the auto-trigger is the live path.
@@ -43,13 +46,6 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         sells while keeping per-swap price-impact bounded for the common case.
     uint256 public constant SWAP_THRESHOLD = TOTAL_SUPPLY / 2000;
 
-    /// @notice Minimum seconds between two successful `_swapBack` calls. Set to one Ethereum
-    ///         mainnet slot so the contract performs at most ~1 swapback per block: every
-    ///         transaction in a single block shares an identical `block.timestamp`, so the
-    ///         check `block.timestamp >= lastSwapbackTimestamp + 12` is necessarily false for
-    ///         any second swap in the same block (`T >= T + 12` cannot hold).
-    uint256 public constant SWAPBACK_COOLDOWN = 12;
-
     /////////////////////////// pure storage ///////////////////////
 
     /// @dev Re-entrancy guard for the swap-back path. When true, `_update` short-circuits the
@@ -57,11 +53,12 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///      ERC20 transfer. Lives in transient storage — auto-clears at end of tx, no SSTORE cost.
     bool internal transient _inSwap;
 
-    /// @notice Block timestamp of the most recent successful `_swapBack`. Zero until the first
-    ///         swapback runs. Used by both the `_update` auto-trigger and the manual `swapBack`
-    ///         entry point to enforce `SWAPBACK_COOLDOWN`. Stored as uint40 so it packs into the
-    ///         parent `LivoTaxableToken` slot alongside `graduationTimestamp`.
-    uint40 public lastSwapbackTimestamp;
+    /// @notice `block.number` of the most recent successful `_swapBack`. Zero until the first
+    ///         swapback runs. The auto-trigger and the manual `swapBack` both gate on
+    ///         `block.number > lastSwapbackBlock` so the contract performs at most one
+    ///         swap-back per block. uint48 packs into the parent `LivoTaxableToken` slot
+    ///         alongside `graduationTimestamp`.
+    uint48 public lastSwapbackBlock;
 
     //////////////////////// Events //////////////////////
 
@@ -74,11 +71,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
 
     //////////////////////// Errors //////////////////////
 
-    /// @notice Thrown by manual `swapBack` when the previous swapback finished less than
-    ///         `SWAPBACK_COOLDOWN` seconds ago. The auto-trigger in `_update` does NOT revert
-    ///         on cooldown — it silently skips the swap so sells inside the cooldown window
-    ///         keep working.
-    error SwapbackCooldownNotMet();
+    /// @notice Thrown by manual `swapBack` when a swap-back has already settled in the current
+    ///         block. The auto-trigger in `_update` does NOT revert on this condition — it
+    ///         silently skips the swap so the second sell in the block keeps settling.
+    error SwapbackAlreadyInThisBlock();
 
     //////////////////////////////////////////////////////
 
@@ -143,9 +139,9 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     ///         when `balance >= SWAP_THRESHOLD`, OR — after the tax window expires — when any
     ///         non-zero balance remains, so a sub-threshold residual gets drained on the next sell
     ///         instead of stranding forever (no new tax accrues post-window to push it across).
-    ///         Both branches are additionally gated on `SWAPBACK_COOLDOWN` (12s) so the contract
-    ///         performs at most one swapback per Ethereum mainnet block — same-block sells share
-    ///         `block.timestamp` and silently skip the auto-trigger after the first swap.
+    ///         Both branches are additionally gated on `block.number > lastSwapbackBlock` so the
+    ///         contract performs at most one swap-back per block — further same-block sells
+    ///         silently skip the auto-trigger.
     ///         Any excess stays on the contract and is drained on the next qualifying sell.
     ///      4. If we're in the post-graduation tax window AND the transfer touches the pair AND
     ///         the source is not the graduator (which moves the initial liquidity), divert
@@ -180,11 +176,10 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         // produces a `_update(graduator, pair, ...)` while the pair still has zero reserves, so
         // firing `_swapBack` against it would revert the entire graduation tx. Anyone could grief
         // graduation by pre-funding `address(this)` with `>= SWAP_THRESHOLD` tokens before it.
-        // Cooldown check pre-gates both auto-trigger branches. Putting it before the `balanceOf`
-        // SLOAD means sells inside the cooldown window pay nothing extra. The slot holding
-        // `lastSwapbackTimestamp` is also packed with `graduationTimestamp`, so the SLOAD here
-        // pre-warms the slot read by the tax-window branch below.
-        if (isSell && from != graduator && block.timestamp >= uint256(lastSwapbackTimestamp) + SWAPBACK_COOLDOWN) {
+        // Per-block cap pre-gates both auto-trigger branches. `lastSwapbackBlock` shares the
+        // parent's `graduationTimestamp` slot, so this SLOAD also pre-warms the slot read by
+        // the tax-window branch below.
+        if (isSell && from != graduator && block.number > uint256(lastSwapbackBlock)) {
             uint256 contractBalance = balanceOf(address(this));
             if (contractBalance >= SWAP_THRESHOLD) {
                 uint256 swapAmount = contractBalance > 2 * SWAP_THRESHOLD ? 2 * SWAP_THRESHOLD : contractBalance;
@@ -228,13 +223,13 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
     /// @dev `address(this).balance` is forwarded in full (not just the swap output): any ETH that
     ///      may have arrived through `receive()` between swap-backs is treated as un-routed fees
     ///      and routed through the same path. Avoids ETH ever sitting idle in the contract.
-    /// @dev Enforces `SWAPBACK_COOLDOWN` (12s) between consecutive swapbacks. Reverts with
-    ///      `SwapbackCooldownNotMet` if called too soon — `_update` pre-checks the same condition
-    ///      and skips the auto-trigger, so in practice only the manual `swapBack` entry point ever
-    ///      surfaces this revert.
+    /// @dev Enforces at most one swap-back per block. Reverts with `SwapbackAlreadyInThisBlock`
+    ///      if a swap-back has already settled in this block — `_update` pre-checks the same
+    ///      condition and skips the auto-trigger, so in practice only the manual `swapBack`
+    ///      entry point ever surfaces this revert.
     function _swapBack(uint256 tokenAmount, uint256 amountOutMinWei) internal {
         if (tokenAmount == 0) return;
-        require(block.timestamp >= uint256(lastSwapbackTimestamp) + SWAPBACK_COOLDOWN, SwapbackCooldownNotMet());
+        require(block.number > uint256(lastSwapbackBlock), SwapbackAlreadyInThisBlock());
 
         _inSwap = true;
 
@@ -247,7 +242,7 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         );
 
         _inSwap = false;
-        lastSwapbackTimestamp = uint40(block.timestamp);
+        lastSwapbackBlock = uint48(block.number);
 
         uint256 ethBalance = address(this).balance;
         emit CreatorTaxSwapback(tokenAmount, ethBalance);

--- a/src/tokens/LivoTaxableTokenUniV2.sol
+++ b/src/tokens/LivoTaxableTokenUniV2.sol
@@ -5,7 +5,6 @@ import {LivoTaxableToken} from "src/tokens/LivoTaxableToken.sol";
 import {LivoToken} from "src/tokens/LivoToken.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
 import {TaxConfigInit} from "src/interfaces/ILivoTaxableToken.sol";
-import {ILivoMasterFeeHandler} from "src/interfaces/ILivoMasterFeeHandler.sol";
 import {IUniswapV2Router} from "src/interfaces/IUniswapV2Router.sol";
 
 /// this line below can be adjusted to import the Sepolia addresses when deploying in sepolia
@@ -64,9 +63,9 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
 
     /// @notice Emitted whenever the contract auto- or manually-swaps accumulated tax tokens to ETH
     ///         and forwards the proceeds to the master fee handler. `ethAmount` is the ETH
-    ///         routed through `feeHandler.depositFees` for this swap-back, i.e. the tax
-    ///         actually accrued to the creator (and any direct receivers) for the swap window
-    ///         covered by this back-swap.
+    ///         pushed via `_accrueFees` (plain ETH transfer to the handler) for this swap-back,
+    ///         i.e. the tax actually accrued to the creator (and any direct receivers) for the
+    ///         swap window covered by this back-swap.
     event CreatorTaxSwapback(uint256 tokenAmountIn, uint256 ethAmount);
 
     //////////////////////// Errors //////////////////////
@@ -247,8 +246,8 @@ contract LivoTaxableTokenUniV2 is LivoTaxableToken {
         uint256 ethBalance = address(this).balance;
         emit CreatorTaxSwapback(tokenAmount, ethBalance);
 
-        if (ethBalance > 0) {
-            ILivoMasterFeeHandler(feeHandler).depositFees{value: ethBalance}(address(this));
-        }
+        // Plain ETH push: the handler's `receive()` attributes the deposit via `msg.sender`,
+        // so no `address(this)` argument is needed. `_accrueFees` no-ops on zero balance.
+        _accrueFees(ethBalance);
     }
 }

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -82,8 +82,8 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     error TransferToPairBeforeGraduationNotAllowed();
     error CannotSelfTransfer();
     error Unauthorized();
-    error EthTransferFailed();
     error InvalidFeeHandler();
+    error FeeHandlerMustBeEOA();
 
     //////////////////////////////////////////////////////
 
@@ -183,26 +183,37 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     /// @dev Sends `amount` wei to the fee handler with empty calldata. The handler's `receive()`
     ///      attributes the deposit to `msg.sender` (this token), so the redundant `address(this)`
     ///      argument is no longer needed. No-op on zero.
+    /// @dev The `.call` result is intentionally ignored. If the transfer fails (e.g. a malicious
+    ///      contract receiver reverts on `receive()`, or the master handler reverts on an
+    ///      unregistered config), the ETH stays in this contract instead of bubbling the revert.
+    ///      The V2 swap-back path sources its push from `address(this).balance`, so any residual
+    ///      from a failed transfer is rolled into the next swap-back automatically. External
+    ///      callers of `accrueFees()` should consider the residual likewise recoverable on a
+    ///      future swap-back / accrual that lands successfully.
     function _accrueFees(uint256 amount) internal {
         if (amount == 0) return;
+        // Failure ignored intentionally — ETH stays in the contract and rolls into the next push.
+        // forge-lint: disable-next-line(unchecked-call)
         (bool ok,) = feeHandler.call{value: amount}("");
-        require(ok, EthTransferFailed());
+        ok;
     }
 
     /// @notice Rotates the fee-handler address. Callable by the token owner OR by the launchpad
     ///         owner. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on
     ///         those tokens only the launchpad owner can call.
-    /// @dev    Primary use case: rotate the single direct receiver of a V2 taxable token deployed
-    ///         via `LivoFactoryUniV2Unified`'s direct-handler path (`token.feeHandler == receiver`).
-    ///         Pointing back at the master fee handler when this token was never registered there
-    ///         will brick swapbacks (master handler's `_depositSingle` reverts on the unregistered
-    ///         config). Redirecting a master-routed token away from the master handler drains all
-    ///         future fee flow to the new address; the master handler's stored recipient set is
-    ///         orphaned (existing pending claims remain claimable). Both are admin foot-guns; the
-    ///         function trusts the caller and does not gate by current state.
+    /// @dev    Requires BOTH the current and the new `feeHandler` to be EOAs
+    ///         (`code.length == 0`). Consequence:
+    ///         - Master-fee-handler-routed tokens cannot rotate at all (current is a contract,
+    ///           so the precondition fails) — fee-handler is effectively immutable for them.
+    ///         - Direct-handler tokens (single-direct-receiver path) can only rotate to another
+    ///           EOA — never back into a master fee handler.
+    ///         Keeps the indexer's `TokenFeeData.isDirectFeeHandlerEOA` trivially correct
+    ///         post-rotation: a rotation can only ever happen between EOAs, so the flag stays
+    ///         `true` and the swap-back handler remains the sole accounting signal.
     function setFeeHandler(address newFeeHandler) external {
         require(msg.sender == owner || msg.sender == launchpad.owner(), Unauthorized());
         require(newFeeHandler != address(0), InvalidFeeHandler());
+        require(feeHandler.code.length == 0 && newFeeHandler.code.length == 0, FeeHandlerMustBeEOA());
         address old = feeHandler;
         feeHandler = newFeeHandler;
         emit FeeHandlerChanged(old, newFeeHandler);

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -82,6 +82,7 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     error TransferToPairBeforeGraduationNotAllowed();
     error CannotSelfTransfer();
     error Unauthorized();
+    error EthTransferFailed();
 
     //////////////////////////////////////////////////////
 
@@ -171,9 +172,20 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
         ILivoMasterFeeHandler(feeHandler).registerToken(feeShares);
     }
 
-    /// @notice Routes ETH fees to the fee handler for this token
+    /// @notice Routes ETH fees to the fee handler for this token.
+    /// @dev Thin external wrapper around `_accrueFees` so subclasses (and internal callers like
+    ///      taxable-token swap-backs) can push fees without re-entering the external function.
     function accrueFees() external payable {
-        ILivoMasterFeeHandler(feeHandler).depositFees{value: msg.value}(address(this));
+        _accrueFees(msg.value);
+    }
+
+    /// @dev Sends `amount` wei to the fee handler with empty calldata. The handler's `receive()`
+    ///      attributes the deposit to `msg.sender` (this token), so the redundant `address(this)`
+    ///      argument is no longer needed. No-op on zero.
+    function _accrueFees(uint256 amount) internal {
+        if (amount == 0) return;
+        (bool ok,) = feeHandler.call{value: amount}("");
+        require(ok, EthTransferFailed());
     }
 
     //////////////////////// view functions ////////////////////////

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -35,10 +35,9 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     /// @notice Launchpad address
     LivoLaunchpad public launchpad;
 
-    /// @notice Contract handling fees for this token. Set once at initialization and immutable
-    ///         thereafter — there is no admin path to rotate it. For master-routed tokens this is
-    ///         the `LivoMasterFeeHandler`; for V2 taxable single-direct-receiver tokens it is the
-    ///         receiver address itself.
+    /// @notice Fee handler for this token. Set at init and immutable thereafter (no rotation
+    ///         path). Usually `LivoMasterFeeHandler`; for V2 taxable single-direct-receiver
+    ///         tokens it's the receiver address itself.
     address public feeHandler;
 
     /// @notice Factory that initialized this token. Allowed to perform one-shot fee registration.
@@ -163,27 +162,18 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     }
 
     /// @notice Routes ETH fees to the fee handler for this token.
-    /// @dev Thin external wrapper around `_accrueFees` so subclasses (and internal callers like
-    ///      taxable-token swap-backs) can push fees without re-entering the external function.
     function accrueFees() external payable {
         _accrueFees(msg.value);
     }
 
-    /// @dev Sends `amount` wei to the fee handler with empty calldata. The handler's `receive()`
-    ///      attributes the deposit to `msg.sender` (this token), so the redundant `address(this)`
-    ///      argument is no longer needed. No-op on zero.
-    /// @dev The `.call` result is intentionally ignored. If the transfer fails (e.g. a malicious
-    ///      contract receiver reverts on `receive()`, or the master handler reverts on an
-    ///      unregistered config), the ETH stays in this contract instead of bubbling the revert.
-    ///      The V2 swap-back path sources its push from `address(this).balance`, so any residual
-    ///      from a failed transfer is rolled into the next swap-back automatically. External
-    ///      callers of `accrueFees()` should consider the residual likewise recoverable on a
-    ///      future swap-back / accrual that lands successfully.
+    /// @dev Plain ETH push to the fee handler; the handler's `receive()` attributes the deposit
+    ///      via `msg.sender`. Transfer failures (e.g. hostile direct receiver reverting on
+    ///      `receive()`) are intentionally swallowed so they don't bubble into swap-backs or
+    ///      `accrueFees` callers — residual ETH stays on the contract and rolls into the next
+    ///      successful push (V2 swap-back sources from `address(this).balance`).
     function _accrueFees(uint256 amount) internal {
         if (amount == 0) return;
-        // No indexer handler for now; informational only.
         emit RouteFees(feeHandler, amount);
-        // Failure ignored intentionally — ETH stays in the contract and rolls into the next push.
         // forge-lint: disable-next-line(unchecked-call)
         (bool ok,) = feeHandler.call{value: amount}("");
         ok;

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -178,6 +178,8 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     /// @dev Thin external wrapper around `_accrueFees` so subclasses (and internal callers like
     ///      taxable-token swap-backs) can push fees without re-entering the external function.
     function accrueFees() external payable {
+        // No indexer handler for now; informational only.
+        emit RouteFees(feeHandler, msg.value);
         _accrueFees(msg.value);
     }
 

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -35,7 +35,10 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     /// @notice Launchpad address
     LivoLaunchpad public launchpad;
 
-    /// @notice Contract handling fees for this token
+    /// @notice Contract handling fees for this token. Set once at initialization and immutable
+    ///         thereafter — there is no admin path to rotate it. For master-routed tokens this is
+    ///         the `LivoMasterFeeHandler`; for V2 taxable single-direct-receiver tokens it is the
+    ///         receiver address itself.
     address public feeHandler;
 
     /// @notice Factory that initialized this token. Allowed to perform one-shot fee registration.
@@ -82,8 +85,6 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     error TransferToPairBeforeGraduationNotAllowed();
     error CannotSelfTransfer();
     error Unauthorized();
-    error InvalidFeeHandler();
-    error FeeHandlerMustBeEOA();
 
     //////////////////////////////////////////////////////
 
@@ -196,27 +197,6 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
         // forge-lint: disable-next-line(unchecked-call)
         (bool ok,) = feeHandler.call{value: amount}("");
         ok;
-    }
-
-    /// @notice Rotates the fee-handler address. Callable by the token owner OR by the launchpad
-    ///         owner. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on
-    ///         those tokens only the launchpad owner can call.
-    /// @dev    Requires BOTH the current and the new `feeHandler` to be EOAs
-    ///         (`code.length == 0`). Consequence:
-    ///         - Master-fee-handler-routed tokens cannot rotate at all (current is a contract,
-    ///           so the precondition fails) — fee-handler is effectively immutable for them.
-    ///         - Direct-handler tokens (single-direct-receiver path) can only rotate to another
-    ///           EOA — never back into a master fee handler.
-    ///         Keeps the indexer's `TokenFeeData.isDirectFeeHandlerEOA` trivially correct
-    ///         post-rotation: a rotation can only ever happen between EOAs, so the flag stays
-    ///         `true` and the swap-back handler remains the sole accounting signal.
-    function setFeeHandler(address newFeeHandler) external {
-        require(msg.sender == owner || msg.sender == launchpad.owner(), Unauthorized());
-        require(newFeeHandler != address(0), InvalidFeeHandler());
-        require(feeHandler.code.length == 0 && newFeeHandler.code.length == 0, FeeHandlerMustBeEOA());
-        address old = feeHandler;
-        feeHandler = newFeeHandler;
-        emit FeeHandlerChanged(old, newFeeHandler);
     }
 
     //////////////////////// view functions ////////////////////////

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -83,6 +83,7 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     error CannotSelfTransfer();
     error Unauthorized();
     error EthTransferFailed();
+    error InvalidFeeHandler();
 
     //////////////////////////////////////////////////////
 
@@ -188,12 +189,26 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
         require(ok, EthTransferFailed());
     }
 
-    //////////////////////// view functions ////////////////////////
-
-    /// @notice Returns the underlying fee receiver addresses and their share in basis points
-    function getFeeReceivers() external view returns (address[] memory, uint256[] memory) {
-        return ILivoMasterFeeHandler(feeHandler).getRecipients(address(this));
+    /// @notice Rotates the fee-handler address. Callable by the token owner OR by the launchpad
+    ///         owner. V2-family tokens are deployed ownerless (`tokenOwner = address(0)`), so on
+    ///         those tokens only the launchpad owner can call.
+    /// @dev    Primary use case: rotate the single direct receiver of a V2 taxable token deployed
+    ///         via `LivoFactoryUniV2Unified`'s direct-handler path (`token.feeHandler == receiver`).
+    ///         Pointing back at the master fee handler when this token was never registered there
+    ///         will brick swapbacks (master handler's `_depositSingle` reverts on the unregistered
+    ///         config). Redirecting a master-routed token away from the master handler drains all
+    ///         future fee flow to the new address; the master handler's stored recipient set is
+    ///         orphaned (existing pending claims remain claimable). Both are admin foot-guns; the
+    ///         function trusts the caller and does not gate by current state.
+    function setFeeHandler(address newFeeHandler) external {
+        require(msg.sender == owner || msg.sender == launchpad.owner(), Unauthorized());
+        require(newFeeHandler != address(0), InvalidFeeHandler());
+        address old = feeHandler;
+        feeHandler = newFeeHandler;
+        emit FeeHandlerChanged(old, newFeeHandler);
     }
+
+    //////////////////////// view functions ////////////////////////
 
     /// @notice Default tax config returning no taxes. Overridden by taxable token implementations.
     function getTaxConfig() external view virtual returns (ILivoToken.TaxConfig memory config) {}

--- a/src/tokens/LivoToken.sol
+++ b/src/tokens/LivoToken.sol
@@ -59,18 +59,6 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     ///          launchpad, which runs BEFORE `_initializeSniperProtection` sets `launchTimestamp`.
     ///          At that moment the window-active check returns early on its own, so the
     ///          `from == factoryAddr` branch is unreachable with `factoryAddr == 0`.
-    /// @dev ⚠️ FUTURE FOOT-GUN: any new path that lets `_update` fire with `to == address(0)`
-    ///      OR with `from == address(0)` AFTER `launchTimestamp` is set would silently bypass
-    ///      the sniper caps. Concrete cases to watch out for:
-    ///        - a custom transfer override (or alternate ERC20 base) that drops the
-    ///          zero-recipient guard, enabling burns through `_update`;
-    ///        - any new `_mint` call site that runs after init (e.g. a rebase or inflation
-    ///          hook), since post-init mints have `from == address(0)`;
-    ///        - any new internal call site that issues `_update(*, address(0), x)` directly
-    ///          (e.g. a "burn from launchpad" admin path).
-    ///      If any such path is introduced, harden the exemption: pass a non-zero sentinel
-    ///      for the cleared state, or have `_checkSniperProtection` add explicit
-    ///      `factoryAddr != address(0)` guards around the factoryAddr short-circuits.
     address internal transient tokenFactory;
 
     /// @notice Token name
@@ -178,8 +166,6 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     /// @dev Thin external wrapper around `_accrueFees` so subclasses (and internal callers like
     ///      taxable-token swap-backs) can push fees without re-entering the external function.
     function accrueFees() external payable {
-        // No indexer handler for now; informational only.
-        emit RouteFees(feeHandler, msg.value);
         _accrueFees(msg.value);
     }
 
@@ -195,6 +181,8 @@ contract LivoToken is ERC20, ILivoToken, Initializable {
     ///      future swap-back / accrual that lands successfully.
     function _accrueFees(uint256 amount) internal {
         if (amount == 0) return;
+        // No indexer handler for now; informational only.
+        emit RouteFees(feeHandler, amount);
         // Failure ignored intentionally — ETH stays in the contract and rolls into the next push.
         // forge-lint: disable-next-line(unchecked-call)
         (bool ok,) = feeHandler.call{value: amount}("");

--- a/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
+++ b/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
@@ -5,13 +5,11 @@ import "forge-std/Test.sol";
 import {LaunchpadBaseTests} from "test/launchpad/base.t.sol";
 import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
-import {LivoToken} from "src/tokens/LivoToken.sol";
 
 /// @notice Coverage for the V2 taxable + single-direct-receiver path in `LivoFactoryUniV2Unified`.
 ///         The factory's `_resolveFeeHandlerForInit` override sets `token.feeHandler = receiver`
 ///         (bypassing the master fee handler) and emits `DirectSingleFeeReceiver`. Negative paths
-///         assert all other configurations still register with the master handler. Also covers
-///         the new `LivoToken.setFeeHandler` admin-rotation entry point.
+///         assert all other configurations still register with the master handler.
 contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
     AcceptingReceiver internal smartReceiver;
     RejectingReceiver internal rejectingReceiver;
@@ -103,104 +101,6 @@ contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
 
         assertEq(address(rejectingReceiver).balance, receiverBefore, "rejecting receiver got nothing");
         assertEq(token.balance, tokenBefore + 1 ether, "ETH stays on the token contract");
-    }
-
-    // ============================================================
-    // setFeeHandler — admin rotation entry point
-    // ============================================================
-
-    function test_setFeeHandler_launchpadOwnerCanRotateDirectReceiver() public {
-        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
-        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        vm.prank(creator);
-        address token = factoryV2Unified.createToken(
-            "Rot", "RT", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
-        );
-
-        vm.expectEmit(true, true, true, true, token);
-        emit ILivoToken.FeeHandlerChanged(alice, bob);
-        vm.prank(admin); // launchpad.owner() is admin
-        ILivoToken(token).setFeeHandler(bob);
-
-        assertEq(ILivoToken(token).feeHandler(), bob, "feeHandler rotated to bob");
-
-        uint256 bobBefore = bob.balance;
-        uint256 aliceBefore = alice.balance;
-        vm.deal(buyer, 0.25 ether);
-        vm.prank(buyer);
-        ILivoToken(token).accrueFees{value: 0.25 ether}();
-        assertEq(bob.balance, bobBefore + 0.25 ether, "bob now receives fees");
-        assertEq(alice.balance, aliceBefore, "alice no longer receives");
-    }
-
-    function test_setFeeHandler_unauthorizedCallerReverts() public {
-        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
-        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        vm.prank(creator);
-        address token = factoryV2Unified.createToken(
-            "Auth", "AU", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
-        );
-
-        // V2 tokens are ownerless, so creator isn't `owner` and admin is the only valid caller.
-        vm.expectRevert(LivoToken.Unauthorized.selector);
-        vm.prank(buyer);
-        ILivoToken(token).setFeeHandler(bob);
-
-        vm.expectRevert(LivoToken.Unauthorized.selector);
-        vm.prank(creator);
-        ILivoToken(token).setFeeHandler(bob);
-    }
-
-    function test_setFeeHandler_rejectsZeroAddress() public {
-        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
-        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        vm.prank(creator);
-        address token = factoryV2Unified.createToken(
-            "Zero", "ZR", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
-        );
-
-        vm.expectRevert(LivoToken.InvalidFeeHandler.selector);
-        vm.prank(admin);
-        ILivoToken(token).setFeeHandler(address(0));
-    }
-
-    function test_setFeeHandler_rejectsContractReceiver() public {
-        // EOA-only gate (new side): setFeeHandler refuses any address with bytecode. Intent is to
-        // prevent rotating the receiver back into a master fee handler (or any other contract) on
-        // tokens where the indexer's isDirectFeeHandlerEOA flag is true.
-        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
-        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        vm.prank(creator);
-        address token = factoryV2Unified.createToken(
-            "EOA", "EA", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
-        );
-
-        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
-        vm.prank(admin);
-        ILivoToken(token).setFeeHandler(address(smartReceiver));
-
-        // The master fee handler itself is also a contract → rejected.
-        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
-        vm.prank(admin);
-        ILivoToken(token).setFeeHandler(address(feeHandler));
-    }
-
-    function test_setFeeHandler_masterRoutedTokenIsImmutable() public {
-        // EOA-only gate (current side): a master-handler-routed token has `feeHandler = master`
-        // (a contract), so the precondition `current.code.length == 0` fails — the rotation is
-        // impossible. Effectively makes the fee-handler immutable for master-routed tokens.
-        ILivoFactory.FeeShare[] memory fs = _fs(alice); // single non-direct → master-routed
-        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        vm.prank(creator);
-        address token = factoryV2Unified.createToken(
-            "Lock", "LK", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
-        );
-        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "preflight: master-routed");
-
-        // Even rotating to a valid EOA reverts, because the *current* feeHandler is a contract.
-        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
-        vm.prank(admin);
-        ILivoToken(token).setFeeHandler(bob);
     }
 
     // ============================================================

--- a/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
+++ b/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+import {LaunchpadBaseTests} from "test/launchpad/base.t.sol";
+import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
+import {ILivoToken} from "src/interfaces/ILivoToken.sol";
+import {LivoToken} from "src/tokens/LivoToken.sol";
+
+/// @notice Coverage for the V2 taxable + single-direct-receiver path in `LivoFactoryUniV2Unified`.
+///         The factory's `_resolveFeeHandlerForInit` override sets `token.feeHandler = receiver`
+///         (bypassing the master fee handler) and emits `DirectSingleFeeReceiver`. Negative paths
+///         assert all other configurations still register with the master handler. Also covers
+///         the new `LivoToken.setFeeHandler` admin-rotation entry point.
+contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
+    AcceptingReceiver internal smartReceiver;
+    RejectingReceiver internal rejectingReceiver;
+
+    function setUp() public virtual override {
+        super.setUp();
+        smartReceiver = new AcceptingReceiver();
+        rejectingReceiver = new RejectingReceiver();
+    }
+
+    // ============================================================
+    // Happy path — V2 taxable + single direct receiver
+    // ============================================================
+
+    function test_v2Taxable_singleDirectEOA_pointsFeeHandlerAtReceiver() public {
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+
+        vm.recordLogs();
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Direct", "DR", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        assertEq(ILivoToken(token).feeHandler(), alice, "feeHandler should be the EOA receiver");
+
+        // Master handler is NOT registered for this token (registerFees was skipped).
+        assertFalse(feeHandler.isDirectReceiver(token, alice), "alice should not be in master.isDirectReceiver");
+        assertEq(feeHandler.getDirectReceivers(token).length, 0, "no direct receivers on master");
+        (address[] memory addrs,) = feeHandler.getRecipients(token);
+        assertEq(addrs.length, 0, "no recipients registered with master");
+
+        // DirectSingleFeeReceiver(token, alice) was emitted.
+        _assertDirectSingleFeeReceiverEmitted(token, alice);
+    }
+
+    function test_v2Taxable_singleDirectEOA_accrueFeesLandsAtReceiver() public {
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Route", "RT", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        uint256 aliceBefore = alice.balance;
+        uint256 handlerBefore = address(feeHandler).balance;
+        vm.deal(buyer, 0.5 ether);
+        vm.prank(buyer);
+        ILivoToken(token).accrueFees{value: 0.5 ether}();
+
+        assertEq(alice.balance, aliceBefore + 0.5 ether, "alice gets the full fee directly");
+        assertEq(address(feeHandler).balance, handlerBefore, "master handler balance unchanged");
+    }
+
+    function test_v2Taxable_singleDirect_smartWalletReceiver_isAllowed() public {
+        // User chose to allow contract receivers (no EOA gate). The direct path still applies and
+        // ETH lands at the contract.
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(address(smartReceiver));
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Smart", "SM", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        assertEq(ILivoToken(token).feeHandler(), address(smartReceiver), "feeHandler is the smart wallet");
+        uint256 before = address(smartReceiver).balance;
+        vm.deal(buyer, 0.3 ether);
+        vm.prank(buyer);
+        ILivoToken(token).accrueFees{value: 0.3 ether}();
+        assertEq(address(smartReceiver).balance, before + 0.3 ether, "smart wallet receives fees");
+    }
+
+    function test_v2Taxable_singleDirect_rejectingReceiver_bricksAccrual() public {
+        // Documents the trade-off: no master-handler pending-claims fallback exists for the
+        // direct path, so a receiver reverting on receive() DoSes accrueFees / future swap-backs.
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(address(rejectingReceiver));
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Reject", "RJ", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        vm.deal(buyer, 1 ether);
+        vm.prank(buyer);
+        vm.expectRevert(LivoToken.EthTransferFailed.selector);
+        ILivoToken(token).accrueFees{value: 1 ether}();
+    }
+
+    // ============================================================
+    // setFeeHandler — admin rotation entry point
+    // ============================================================
+
+    function test_setFeeHandler_launchpadOwnerCanRotateDirectReceiver() public {
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Rot", "RT", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        vm.expectEmit(true, true, true, true, token);
+        emit ILivoToken.FeeHandlerChanged(alice, bob);
+        vm.prank(admin); // launchpad.owner() is admin
+        ILivoToken(token).setFeeHandler(bob);
+
+        assertEq(ILivoToken(token).feeHandler(), bob, "feeHandler rotated to bob");
+
+        uint256 bobBefore = bob.balance;
+        uint256 aliceBefore = alice.balance;
+        vm.deal(buyer, 0.25 ether);
+        vm.prank(buyer);
+        ILivoToken(token).accrueFees{value: 0.25 ether}();
+        assertEq(bob.balance, bobBefore + 0.25 ether, "bob now receives fees");
+        assertEq(alice.balance, aliceBefore, "alice no longer receives");
+    }
+
+    function test_setFeeHandler_unauthorizedCallerReverts() public {
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Auth", "AU", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        // V2 tokens are ownerless, so creator isn't `owner` and admin is the only valid caller.
+        vm.expectRevert(LivoToken.Unauthorized.selector);
+        vm.prank(buyer);
+        ILivoToken(token).setFeeHandler(bob);
+
+        vm.expectRevert(LivoToken.Unauthorized.selector);
+        vm.prank(creator);
+        ILivoToken(token).setFeeHandler(bob);
+    }
+
+    function test_setFeeHandler_rejectsZeroAddress() public {
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Zero", "ZR", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        vm.expectRevert(LivoToken.InvalidFeeHandler.selector);
+        vm.prank(admin);
+        ILivoToken(token).setFeeHandler(address(0));
+    }
+
+    // ============================================================
+    // Negative paths — master handler must still be used
+    // ============================================================
+
+    function test_v2Taxable_singleClaimable_usesMasterHandler() public {
+        // Single receiver but directFeesEnabled=false → not the direct path.
+        ILivoFactory.FeeShare[] memory fs = _fs(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Claim", "CL", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "feeHandler is master");
+        (address[] memory addrs, uint256[] memory bps) = feeHandler.getRecipients(token);
+        assertEq(addrs.length, 1, "1 recipient registered with master");
+        assertEq(addrs[0], alice, "alice registered as recipient");
+        assertEq(bps[0], 10_000, "alice gets 10000 bps");
+        assertFalse(feeHandler.isDirectReceiver(token, alice), "non-direct (claimable) entry");
+    }
+
+    function test_v2Taxable_multiRecipient_oneDirect_usesMasterHandler() public {
+        // Two receivers (one direct) → resolver requires length==1, so this falls back to master.
+        ILivoFactory.FeeShare[] memory fs = new ILivoFactory.FeeShare[](2);
+        fs[0] = ILivoFactory.FeeShare({account: alice, shares: 6_000, directFeesEnabled: true});
+        fs[1] = ILivoFactory.FeeShare({account: bob, shares: 4_000, directFeesEnabled: false});
+
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Multi", "MX", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "multi-recipient stays on master");
+        assertTrue(feeHandler.isDirectReceiver(token, alice), "alice still registered as direct");
+    }
+
+    function test_v2NonTaxable_singleDirect_usesMasterHandler() public {
+        // Non-taxable V2 impl → resolver hook requires the taxable impls, so master handler wins.
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoToken));
+        vm.prank(creator);
+        address token =
+            factoryV2Unified.createToken("Plain", "PL", salt, fs, _noSs(), _emptyTaxCfg(), _emptyAntiSniperCfg());
+
+        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "non-taxable V2 uses master");
+        assertTrue(feeHandler.isDirectReceiver(token, alice), "alice registered with master");
+    }
+
+    function test_v4Taxable_singleDirect_usesMasterHandler() public {
+        // V4 factory keeps the default `_resolveFeeHandlerForInit` → master handler always used.
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoTaxToken));
+        vm.prank(creator);
+        address token = factoryV4Unified.createToken(
+            "V4Tax", "V4", salt, fs, _noSs(), false, _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "V4 always uses master");
+        assertTrue(feeHandler.isDirectReceiver(token, alice), "V4 direct receiver registered with master");
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    /// @dev Scans recorded logs for `DirectSingleFeeReceiver(token, receiver)` and asserts both fields.
+    function _assertDirectSingleFeeReceiverEmitted(address expectedToken, address expectedReceiver) internal {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = ILivoFactory.DirectSingleFeeReceiver.selector;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length >= 2 && logs[i].topics[0] == sig) {
+                address loggedToken = address(uint160(uint256(logs[i].topics[1])));
+                if (loggedToken != expectedToken) continue;
+                address receiver = abi.decode(logs[i].data, (address));
+                assertEq(receiver, expectedReceiver, "DirectSingleFeeReceiver receiver mismatch");
+                return;
+            }
+        }
+        revert("DirectSingleFeeReceiver event not found in logs");
+    }
+}
+
+contract AcceptingReceiver {
+    receive() external payable {}
+}
+
+contract RejectingReceiver {
+    receive() external payable {
+        revert("nope");
+    }
+}

--- a/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
+++ b/test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol
@@ -84,9 +84,10 @@ contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
         assertEq(address(smartReceiver).balance, before + 0.3 ether, "smart wallet receives fees");
     }
 
-    function test_v2Taxable_singleDirect_rejectingReceiver_bricksAccrual() public {
-        // Documents the trade-off: no master-handler pending-claims fallback exists for the
-        // direct path, so a receiver reverting on receive() DoSes accrueFees / future swap-backs.
+    function test_v2Taxable_singleDirect_rejectingReceiver_keepsEthInToken() public {
+        // `_accrueFees` swallows transfer failures (no revert): a receiver reverting on
+        // `receive()` no longer DoSes accrueFees / swap-backs. The ETH stays on the token contract
+        // and rolls into the next swap-back via `address(this).balance`.
         ILivoFactory.FeeShare[] memory fs = _fsDirect(address(rejectingReceiver));
         bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
         vm.prank(creator);
@@ -94,10 +95,14 @@ contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
             "Reject", "RJ", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
         );
 
+        uint256 receiverBefore = address(rejectingReceiver).balance;
+        uint256 tokenBefore = token.balance;
         vm.deal(buyer, 1 ether);
         vm.prank(buyer);
-        vm.expectRevert(LivoToken.EthTransferFailed.selector);
         ILivoToken(token).accrueFees{value: 1 ether}();
+
+        assertEq(address(rejectingReceiver).balance, receiverBefore, "rejecting receiver got nothing");
+        assertEq(token.balance, tokenBefore + 1 ether, "ETH stays on the token contract");
     }
 
     // ============================================================
@@ -157,6 +162,45 @@ contract LivoFactoryUniV2DirectFeeReceiverTest is LaunchpadBaseTests {
         vm.expectRevert(LivoToken.InvalidFeeHandler.selector);
         vm.prank(admin);
         ILivoToken(token).setFeeHandler(address(0));
+    }
+
+    function test_setFeeHandler_rejectsContractReceiver() public {
+        // EOA-only gate (new side): setFeeHandler refuses any address with bytecode. Intent is to
+        // prevent rotating the receiver back into a master fee handler (or any other contract) on
+        // tokens where the indexer's isDirectFeeHandlerEOA flag is true.
+        ILivoFactory.FeeShare[] memory fs = _fsDirect(alice);
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "EOA", "EA", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+
+        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
+        vm.prank(admin);
+        ILivoToken(token).setFeeHandler(address(smartReceiver));
+
+        // The master fee handler itself is also a contract → rejected.
+        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
+        vm.prank(admin);
+        ILivoToken(token).setFeeHandler(address(feeHandler));
+    }
+
+    function test_setFeeHandler_masterRoutedTokenIsImmutable() public {
+        // EOA-only gate (current side): a master-handler-routed token has `feeHandler = master`
+        // (a contract), so the precondition `current.code.length == 0` fails — the rotation is
+        // impossible. Effectively makes the fee-handler immutable for master-routed tokens.
+        ILivoFactory.FeeShare[] memory fs = _fs(alice); // single non-direct → master-routed
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            "Lock", "LK", salt, fs, _noSs(), _taxCfg(0, 400, uint32(7 days)), _emptyAntiSniperCfg()
+        );
+        assertEq(ILivoToken(token).feeHandler(), address(feeHandler), "preflight: master-routed");
+
+        // Even rotating to a valid EOA reverts, because the *current* feeHandler is a contract.
+        vm.expectRevert(LivoToken.FeeHandlerMustBeEOA.selector);
+        vm.prank(admin);
+        ILivoToken(token).setFeeHandler(bob);
     }
 
     // ============================================================

--- a/test/feeHandlers/LivoMasterFeeHandler.receive.t.sol
+++ b/test/feeHandlers/LivoMasterFeeHandler.receive.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {MasterFeeHandlerTestHelpers, MockMasterFeeToken} from "test/helpers/MasterFeeHandlerTestHelpers.sol";
+import {LivoMasterFeeHandler} from "src/feeHandlers/LivoMasterFeeHandler.sol";
+import {ILivoMasterFeeHandler} from "src/interfaces/ILivoMasterFeeHandler.sol";
+import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
+import {ReentrancyGuardTransient} from "lib/openzeppelin-contracts/contracts/utils/ReentrancyGuardTransient.sol";
+
+/// @dev Direct receiver whose `receive()` bounces 1 wei back into the handler. The recursive
+///      transfer hits the handler's `receive()`, which shares the `nonReentrant` guard with the
+///      in-flight outer entry point. The recursion must therefore revert; the outer `.call` to
+///      this receiver returns `ok = false` and the slice is recorded as pending.
+contract HandlerBouncer {
+    LivoMasterFeeHandler internal immutable handler;
+
+    constructor(LivoMasterFeeHandler _handler) {
+        handler = _handler;
+    }
+
+    receive() external payable {
+        (bool ok,) = address(handler).call{value: 1}("");
+        require(ok, "bounce blocked");
+    }
+}
+
+contract LivoMasterFeeHandlerReceiveTests is MasterFeeHandlerTestHelpers {
+    MockMasterFeeToken internal tokenA;
+
+    function setUp() public override {
+        super.setUp();
+        tokenA = _newRegisteredToken(creator, _fs(creator));
+    }
+
+    /// @dev `receive()` attributes the deposit to `msg.sender` (the token). A plain ETH transfer
+    ///      from the token should credit the token's claimable account exactly as
+    ///      `depositFees(token)` would.
+    function test_receive_routesToMsgSenderToken() public {
+        uint256 amount = 1 ether;
+
+        vm.expectEmit(true, false, false, true, address(handler));
+        emit ILivoMasterFeeHandler.CreatorFeesDeposited(address(tokenA), amount);
+
+        vm.deal(address(tokenA), amount);
+        tokenA.accrueFees{value: amount}();
+
+        assertEq(_claimable(address(tokenA), creator), amount, "creator should accrue full deposit");
+    }
+
+    /// @dev Zero-value transfer through `receive()` is a no-op: no event, no state change.
+    function test_receive_zeroValueNoop() public {
+        vm.recordLogs();
+        tokenA.accrueFees{value: 0}();
+
+        assertEq(vm.getRecordedLogs().length, 0, "no events on zero-value receive");
+        assertEq(_claimable(address(tokenA), creator), 0, "claimable unchanged");
+    }
+
+    /// @dev Plain ETH from an unregistered address fails inside the handler with the same
+    ///      array-OOB panic that `depositFees(address)` exhibits for unregistered tokens
+    ///      (`_depositSingle` reads `claimableRecipients[0]` on an empty config). The outer
+    ///      `.call` from the unregistered sender therefore returns `false`. Verified by
+    ///      bypassing the mock's `require(ok, ...)` and inspecting the boolean directly.
+    function test_receive_unregisteredSenderFails() public {
+        MockMasterFeeToken unregistered = _newToken(creator);
+        vm.deal(address(unregistered), 1 ether);
+
+        vm.prank(address(unregistered));
+        (bool ok,) = address(handler).call{value: 1 ether}("");
+        assertFalse(ok, "receive must reject ETH from unregistered sender");
+    }
+
+    /// @dev The `nonReentrant` guard on `receive()` blocks a recursive ETH bounce from a direct
+    ///      receiver. The outer forward to the bouncer sees `ok = false`, so its slice falls
+    ///      back to a pending claim instead of forwarding synchronously. The outer deposit does
+    ///      NOT revert, which preserves the swap-hot-path liveness invariant.
+    function test_receive_nonReentrantBlocksBounceFromDirectReceiver() public {
+        HandlerBouncer bouncer = new HandlerBouncer(handler);
+
+        // Register a token with the bouncer as a direct receiver. Use a fresh token to keep
+        // the assertion surface minimal.
+        ILivoFactory.FeeShare[] memory shares = new ILivoFactory.FeeShare[](1);
+        shares[0] = ILivoFactory.FeeShare({account: address(bouncer), shares: 10_000, directFeesEnabled: true});
+        MockMasterFeeToken bouncerToken = _newRegisteredToken(creator, shares);
+
+        uint256 amount = 1 ether;
+        vm.deal(address(bouncerToken), amount);
+
+        // Outer deposit succeeds. The synchronous forward to the bouncer fails (the bouncer's
+        // recursive transfer reverts under the shared transient guard), so the slice is
+        // recorded as pending and recoverable via `claim()`.
+        bouncerToken.accrueFees{value: amount}();
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(bouncerToken);
+        uint256[] memory pending = handler.getClaimable(tokens, address(bouncer));
+        assertEq(pending[0], amount, "bouncer slice fell back to pending");
+    }
+}

--- a/test/helpers/MasterFeeHandlerTestHelpers.sol
+++ b/test/helpers/MasterFeeHandlerTestHelpers.sol
@@ -25,7 +25,10 @@ contract MockMasterFeeToken {
     }
 
     function accrueFees() external payable {
-        feeHandler.depositFees{value: msg.value}(address(this));
+        // Mirrors the production token: plain ETH transfer to the handler; `receive()` attributes
+        // the deposit via `msg.sender`.
+        (bool ok,) = address(feeHandler).call{value: msg.value}("");
+        require(ok, "accrueFees: transfer failed");
     }
 }
 

--- a/test/integration/fork/base/ForkIntegrationBase.t.sol
+++ b/test/integration/fork/base/ForkIntegrationBase.t.sol
@@ -85,7 +85,7 @@ abstract contract ForkIntegrationBase is ForkIntegrationConfig {
         quoter = LivoQuoter(forkCfg.quoter);
         factoryV2 = LivoFactoryUniV2Unified(forkCfg.factoryV2Unified);
         factoryV4 = LivoFactoryUniV4Unified(forkCfg.factoryV4Unified);
-        feeHandler = LivoMasterFeeHandler(forkCfg.masterFeeHandler);
+        feeHandler = LivoMasterFeeHandler(payable(forkCfg.masterFeeHandler));
 
         _assertDeployedAddressConfig();
     }

--- a/test/tokens/LivoTaxableTokenUniV2.t.sol
+++ b/test/tokens/LivoTaxableTokenUniV2.t.sol
@@ -261,50 +261,43 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         assertEq(IERC20(testToken).balanceOf(address(taxToken)), expectedResidual);
     }
 
-    // ─────────────────────────── Swapback cooldown ───────────────────────────────
+    // ─────────────────────────── Swapback per-block cap ──────────────────────────
 
-    function test_swapbackCooldown_sameBlockDoubleSell_onlyOneSwapback() public {
+    function test_swapbackCap_sameBlockDoubleSell_onlyOneSwapback() public {
         _setupGraduatedTokenWithBuyer();
 
-        // Seed the contract above `2 * SWAP_THRESHOLD` so two consecutive sells would each
-        // satisfy the auto-trigger balance condition. Without the cooldown both would swap;
-        // with the 12s cooldown only the first does.
+        // Seed above `2 * SWAP_THRESHOLD` so two consecutive sells would each satisfy the
+        // auto-trigger balance condition. With the per-block gate only the first swaps.
         deal(testToken, address(taxToken), 3 * taxToken.SWAP_THRESHOLD());
 
         uint256 sellAmount = 500_000e18;
 
-        // First sell: auto-swap fires (lastSwapbackTimestamp was 0).
+        // First sell: auto-swap fires (lastSwapbackBlock was 0).
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        uint256 firstSwapEventCount = _countCreatorTaxSwapbackEvents();
-        assertEq(firstSwapEventCount, 1, "first sell should emit exactly one CreatorTaxSwapback");
+        assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell swaps");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), block.number, "block stamped on first swap");
 
-        // Capture state after first swap. Residual = (seeded - cap) + tax-from-first-sell.
         uint256 balanceAfterFirst = IERC20(testToken).balanceOf(address(taxToken));
         assertGe(balanceAfterFirst, taxToken.SWAP_THRESHOLD(), "residual after first swap must still trigger auto-path");
-        assertEq(uint256(taxToken.lastSwapbackTimestamp()), block.timestamp, "timestamp set on first swap");
 
-        // Second sell IN THE SAME BLOCK (no vm.warp) — block.timestamp is unchanged, so the
-        // cooldown check `T >= T + 12` is false. The auto-trigger is silently skipped.
+        // Second sell IN THE SAME BLOCK (no vm.roll) — auto-trigger is gated → silent skip.
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        uint256 secondSwapEventCount = _countCreatorTaxSwapbackEvents();
-        assertEq(secondSwapEventCount, 0, "same-block second sell must NOT trigger a swapback");
+        assertEq(_countCreatorTaxSwapbackEvents(), 0, "same-block second sell must NOT swap");
 
-        // The residual + the tax from the second sell is still sitting on the contract.
         uint256 balanceAfterSecond = IERC20(testToken).balanceOf(address(taxToken));
         uint256 expectedTaxFromSecondSell = sellAmount * SELL_BPS / 10_000;
         assertEq(
             balanceAfterSecond,
             balanceAfterFirst + expectedTaxFromSecondSell,
-            "residual must accumulate when cooldown blocks the second swap"
+            "residual must accumulate when the per-block gate blocks the second swap"
         );
     }
 
-    function test_swapbackCooldown_adjacentBlocks_bothSwap() public {
+    function test_swapbackCap_adjacentBlocks_bothSwap() public {
         _setupGraduatedTokenWithBuyer();
 
-        // Seed enough balance so two back-to-back swaps are both possible.
         deal(testToken, address(taxToken), 3 * taxToken.SWAP_THRESHOLD());
 
         uint256 sellAmount = 500_000e18;
@@ -313,84 +306,54 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
         assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell swaps");
 
-        // Advance past the cooldown boundary, then sell again — the auto-trigger should fire.
-        vm.warp(block.timestamp + taxToken.SWAPBACK_COOLDOWN() + 1);
+        uint256 stampedBlock = uint256(taxToken.lastSwapbackBlock());
 
+        // Roll to block N+1 → gate opens, auto-trigger fires again.
+        vm.roll(stampedBlock + 1);
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 1, "second sell across cooldown also swaps");
+        assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell in next block swaps again");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock + 1, "block stamp advances");
     }
 
-    function test_swapbackCooldown_autoBoundary() public {
+    function test_swapbackCap_manualRevertsThenSucceeds() public {
         _setupGraduatedTokenWithBuyer();
 
-        deal(testToken, address(taxToken), 3 * taxToken.SWAP_THRESHOLD());
-        uint256 sellAmount = 500_000e18;
-
-        // First sell triggers a swap and stamps `lastSwapbackTimestamp = T`.
-        vm.recordLogs();
-        _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 1);
-        uint256 stampedAt = uint256(taxToken.lastSwapbackTimestamp());
-
-        // At T + 11 (cooldown - 1) the auto-trigger is still gated → no swap.
-        vm.warp(stampedAt + taxToken.SWAPBACK_COOLDOWN() - 1);
-        vm.recordLogs();
-        _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 0, "auto-trigger must skip at cooldown - 1");
-
-        // At T + 12 (exactly cooldown) the auto-trigger is allowed (the check uses `>=`).
-        vm.warp(stampedAt + taxToken.SWAPBACK_COOLDOWN());
-        vm.recordLogs();
-        _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 1, "auto-trigger must fire at exactly cooldown");
-    }
-
-    function test_swapbackCooldown_manualRevertsThenSucceeds() public {
-        _setupGraduatedTokenWithBuyer();
-
-        // Run an initial manual swap to set `lastSwapbackTimestamp`. Use admin (launchpad owner).
+        // First manual swap stamps `lastSwapbackBlock`. Use admin (launchpad owner).
         deal(testToken, address(taxToken), 1_500_000e18);
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
-        uint256 stampedAt = uint256(taxToken.lastSwapbackTimestamp());
-        assertEq(stampedAt, block.timestamp, "first manual swap stamps timestamp");
+        uint256 stampedBlock = uint256(taxToken.lastSwapbackBlock());
+        assertEq(stampedBlock, block.number, "first manual swap stamps block");
 
-        // Re-seed so the next call has tokens to sell. Within cooldown → revert.
+        // Re-seed; second manual call in the SAME block reverts.
         deal(testToken, address(taxToken), 1_500_000e18);
-
         vm.prank(admin);
-        vm.expectRevert(LivoTaxableTokenUniV2.SwapbackCooldownNotMet.selector);
+        vm.expectRevert(LivoTaxableTokenUniV2.SwapbackAlreadyInThisBlock.selector);
         taxToken.swapBack(500_000e18, 1);
 
-        // Just before the boundary → still reverts.
-        vm.warp(stampedAt + taxToken.SWAPBACK_COOLDOWN() - 1);
-        vm.prank(admin);
-        vm.expectRevert(LivoTaxableTokenUniV2.SwapbackCooldownNotMet.selector);
-        taxToken.swapBack(500_000e18, 1);
-
-        // At the boundary → succeeds.
-        vm.warp(stampedAt + taxToken.SWAPBACK_COOLDOWN());
+        // Roll to the next block → succeeds.
+        vm.roll(stampedBlock + 1);
         uint256 feeHandlerEthBefore = address(feeHandler).balance;
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
-        assertGt(address(feeHandler).balance, feeHandlerEthBefore, "second manual swap must forward ETH");
-        assertEq(uint256(taxToken.lastSwapbackTimestamp()), block.timestamp, "timestamp updated on second swap");
+        assertGt(address(feeHandler).balance, feeHandlerEthBefore, "manual swap forwards ETH in next block");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock + 1, "block stamp updated");
     }
 
-    function test_swapbackCooldown_lastSwapbackTimestampTracking() public {
+    function test_swapbackCap_lastSwapbackBlockTracking() public {
         // Pre-graduation, no swap has ever happened.
-        assertEq(uint256(taxToken.lastSwapbackTimestamp()), 0, "zero before any swap");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), 0, "zero before any swap");
 
         _setupGraduatedTokenWithBuyer();
-        assertEq(uint256(taxToken.lastSwapbackTimestamp()), 0, "still zero before any swap, even after graduation");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), 0, "still zero before any swap, even after graduation");
 
         // Trigger the first swap via the manual path.
         deal(testToken, address(taxToken), 1_500_000e18);
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
 
-        assertEq(uint256(taxToken.lastSwapbackTimestamp()), block.timestamp, "stamped to current block on success");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), block.number, "stamped to current block on success");
     }
 
     /// @dev Counts `CreatorTaxSwapback` event emissions in the most recent `vm.recordLogs()` window.

--- a/test/tokens/LivoTaxableTokenUniV2.t.sol
+++ b/test/tokens/LivoTaxableTokenUniV2.t.sol
@@ -316,7 +316,7 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock + 1, "block stamp advances");
     }
 
-    function test_swapbackCap_manualRevertsThenSucceeds() public {
+    function test_swapbackCap_manualSilentlyNoOpsThenSucceeds() public {
         _setupGraduatedTokenWithBuyer();
 
         // First manual swap stamps `lastSwapbackBlock`. Use admin (launchpad owner).
@@ -326,11 +326,25 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         uint256 stampedBlock = uint256(taxToken.lastSwapbackBlock());
         assertEq(stampedBlock, block.number, "first manual swap stamps block");
 
-        // Re-seed; second manual call in the SAME block reverts.
-        deal(testToken, address(taxToken), 1_500_000e18);
+        // Re-seed; second manual call in the SAME block silently no-ops:
+        //   - tx succeeds (no revert),
+        //   - no `CreatorTaxSwapback` event,
+        //   - balance unchanged,
+        //   - no ETH forwarded to fee handler.
+        uint256 balanceBefore = IERC20(testToken).balanceOf(address(taxToken));
+        deal(testToken, address(taxToken), balanceBefore + 1_500_000e18);
+        balanceBefore = IERC20(testToken).balanceOf(address(taxToken));
+        uint256 feeHandlerEthBeforeNoop = address(feeHandler).balance;
+
+        vm.recordLogs();
         vm.prank(admin);
-        vm.expectRevert(LivoTaxableTokenUniV2.SwapbackAlreadyInThisBlock.selector);
         taxToken.swapBack(500_000e18, 1);
+        assertEq(_countCreatorTaxSwapbackEvents(), 0, "same-block manual call must NOT swap");
+        assertEq(
+            IERC20(testToken).balanceOf(address(taxToken)), balanceBefore, "token balance unchanged on silent no-op"
+        );
+        assertEq(address(feeHandler).balance, feeHandlerEthBeforeNoop, "no ETH forwarded on silent no-op");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock, "block stamp unchanged on silent no-op");
 
         // Roll to the next block → succeeds.
         vm.roll(stampedBlock + 1);

--- a/test/tokens/LivoTaxableTokenUniV2.t.sol
+++ b/test/tokens/LivoTaxableTokenUniV2.t.sol
@@ -263,111 +263,144 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
 
     // ─────────────────────────── Swapback per-block cap ──────────────────────────
 
-    function test_swapbackCap_sameBlockDoubleSell_onlyOneSwapback() public {
+    function test_swapbackCap_sameBlockUpToMaxSwapbacks_thenSilent() public {
         _setupGraduatedTokenWithBuyer();
 
-        // Seed above `2 * SWAP_THRESHOLD` so two consecutive sells would each satisfy the
-        // auto-trigger balance condition. With the per-block gate only the first swaps.
-        deal(testToken, address(taxToken), 3 * taxToken.SWAP_THRESHOLD());
+        // Seed well above `MAX_SWAPBACKS_PER_BLOCK * 2 * SWAP_THRESHOLD` so each consecutive
+        // sell still finds `balanceOf(address(this)) >= SWAP_THRESHOLD` at the auto-trigger.
+        // With MAX=2 the first two sells swap; the third hits the counter cap and silently
+        // skips.
+        deal(testToken, address(taxToken), 8 * taxToken.SWAP_THRESHOLD());
 
         uint256 sellAmount = 500_000e18;
+        uint8 maxPerBlock = taxToken.MAX_SWAPBACKS_PER_BLOCK();
+        assertEq(maxPerBlock, 2, "test assumes MAX_SWAPBACKS_PER_BLOCK == 2");
 
-        // First sell: auto-swap fires (lastSwapbackBlock was 0).
+        // First sell: counter resets to 0 (new block), swap fires, counter becomes 1.
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
         assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell swaps");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 1, "counter == 1 after first swap");
         assertEq(uint256(taxToken.lastSwapbackBlock()), block.number, "block stamped on first swap");
 
-        uint256 balanceAfterFirst = IERC20(testToken).balanceOf(address(taxToken));
-        assertGe(balanceAfterFirst, taxToken.SWAP_THRESHOLD(), "residual after first swap must still trigger auto-path");
+        assertGe(
+            IERC20(testToken).balanceOf(address(taxToken)),
+            taxToken.SWAP_THRESHOLD(),
+            "residual after first swap must still trigger auto-path"
+        );
 
-        // Second sell IN THE SAME BLOCK (no vm.roll) — auto-trigger is gated → silent skip.
+        // Second sell IN THE SAME BLOCK — counter goes from 1 to 2, swap still fires.
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 0, "same-block second sell must NOT swap");
+        assertEq(_countCreatorTaxSwapbackEvents(), 1, "second same-block sell still swaps (counter at cap)");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 2, "counter == 2 after second swap");
 
         uint256 balanceAfterSecond = IERC20(testToken).balanceOf(address(taxToken));
-        uint256 expectedTaxFromSecondSell = sellAmount * SELL_BPS / 10_000;
+        assertGe(
+            balanceAfterSecond, taxToken.SWAP_THRESHOLD(), "residual after second swap must still satisfy balance gate"
+        );
+
+        // Third sell IN THE SAME BLOCK — counter already at MAX, silent skip.
+        vm.recordLogs();
+        _swapSellV2(buyer, testToken, sellAmount, 0, true);
+        assertEq(_countCreatorTaxSwapbackEvents(), 0, "third same-block sell must NOT swap");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 2, "counter unchanged on silent no-op");
+
+        uint256 balanceAfterThird = IERC20(testToken).balanceOf(address(taxToken));
+        uint256 expectedTaxFromThirdSell = sellAmount * SELL_BPS / 10_000;
         assertEq(
-            balanceAfterSecond,
-            balanceAfterFirst + expectedTaxFromSecondSell,
-            "residual must accumulate when the per-block gate blocks the second swap"
+            balanceAfterThird,
+            balanceAfterSecond + expectedTaxFromThirdSell,
+            "residual must accumulate when the per-block cap blocks the third swap"
         );
     }
 
-    function test_swapbackCap_adjacentBlocks_bothSwap() public {
+    function test_swapbackCap_adjacentBlocks_counterResets() public {
         _setupGraduatedTokenWithBuyer();
 
-        deal(testToken, address(taxToken), 3 * taxToken.SWAP_THRESHOLD());
+        // Seed high enough that after two same-block swaps (each capped at `2 * SWAP_THRESHOLD`)
+        // the residual still satisfies the auto-trigger balance gate in block N+1.
+        deal(testToken, address(taxToken), 8 * taxToken.SWAP_THRESHOLD());
 
         uint256 sellAmount = 500_000e18;
 
+        // Burn the per-block budget in block N: two swaps fire, counter saturates at 2.
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell swaps");
+        _swapSellV2(buyer, testToken, sellAmount, 0, true);
+        assertEq(_countCreatorTaxSwapbackEvents(), 2, "both same-block sells swap");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 2, "counter saturated at MAX");
 
         uint256 stampedBlock = uint256(taxToken.lastSwapbackBlock());
 
-        // Roll to block N+1 → gate opens, auto-trigger fires again.
+        // Roll to block N+1 → counter resets, auto-trigger fires again.
         vm.roll(stampedBlock + 1);
         vm.recordLogs();
         _swapSellV2(buyer, testToken, sellAmount, 0, true);
-        assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell in next block swaps again");
+        assertEq(_countCreatorTaxSwapbackEvents(), 1, "first sell in next block swaps");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 1, "counter resets to 1 in new block");
         assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock + 1, "block stamp advances");
     }
 
-    function test_swapbackCap_manualSilentlyNoOpsThenSucceeds() public {
+    function test_swapbackCap_manualSilentlyNoOpsAfterMax() public {
         _setupGraduatedTokenWithBuyer();
 
-        // First manual swap stamps `lastSwapbackBlock`. Use admin (launchpad owner).
-        deal(testToken, address(taxToken), 1_500_000e18);
+        // Two manual swaps in block N both succeed; the third silently no-ops.
+        deal(testToken, address(taxToken), 4_500_000e18);
+        vm.prank(admin);
+        taxToken.swapBack(500_000e18, 1);
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
         uint256 stampedBlock = uint256(taxToken.lastSwapbackBlock());
-        assertEq(stampedBlock, block.number, "first manual swap stamps block");
+        assertEq(stampedBlock, block.number, "block stamped");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 2, "counter at MAX after two successes");
 
-        // Re-seed; second manual call in the SAME block silently no-ops:
+        // Third manual call in the SAME block silently no-ops:
         //   - tx succeeds (no revert),
         //   - no `CreatorTaxSwapback` event,
         //   - balance unchanged,
-        //   - no ETH forwarded to fee handler.
+        //   - no ETH forwarded to fee handler,
+        //   - counter unchanged.
         uint256 balanceBefore = IERC20(testToken).balanceOf(address(taxToken));
-        deal(testToken, address(taxToken), balanceBefore + 1_500_000e18);
-        balanceBefore = IERC20(testToken).balanceOf(address(taxToken));
         uint256 feeHandlerEthBeforeNoop = address(feeHandler).balance;
 
         vm.recordLogs();
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
-        assertEq(_countCreatorTaxSwapbackEvents(), 0, "same-block manual call must NOT swap");
+        assertEq(_countCreatorTaxSwapbackEvents(), 0, "third same-block manual call must NOT swap");
         assertEq(
             IERC20(testToken).balanceOf(address(taxToken)), balanceBefore, "token balance unchanged on silent no-op"
         );
         assertEq(address(feeHandler).balance, feeHandlerEthBeforeNoop, "no ETH forwarded on silent no-op");
         assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock, "block stamp unchanged on silent no-op");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 2, "counter unchanged on silent no-op");
 
-        // Roll to the next block → succeeds.
+        // Roll to the next block → counter resets, swap succeeds again.
         vm.roll(stampedBlock + 1);
         uint256 feeHandlerEthBefore = address(feeHandler).balance;
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
         assertGt(address(feeHandler).balance, feeHandlerEthBefore, "manual swap forwards ETH in next block");
         assertEq(uint256(taxToken.lastSwapbackBlock()), stampedBlock + 1, "block stamp updated");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 1, "counter resets to 1 in new block");
     }
 
-    function test_swapbackCap_lastSwapbackBlockTracking() public {
-        // Pre-graduation, no swap has ever happened.
-        assertEq(uint256(taxToken.lastSwapbackBlock()), 0, "zero before any swap");
+    function test_swapbackCap_counterTracking() public {
+        // Pre-graduation: both counters are zero.
+        assertEq(uint256(taxToken.lastSwapbackBlock()), 0, "lastSwapbackBlock zero before any swap");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 0, "swapbacksThisBlock zero before any swap");
 
         _setupGraduatedTokenWithBuyer();
         assertEq(uint256(taxToken.lastSwapbackBlock()), 0, "still zero before any swap, even after graduation");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 0, "counter still zero after graduation");
 
-        // Trigger the first swap via the manual path.
+        // First manual swap stamps both.
         deal(testToken, address(taxToken), 1_500_000e18);
         vm.prank(admin);
         taxToken.swapBack(500_000e18, 1);
 
-        assertEq(uint256(taxToken.lastSwapbackBlock()), block.number, "stamped to current block on success");
+        assertEq(uint256(taxToken.lastSwapbackBlock()), block.number, "lastSwapbackBlock stamped on first swap");
+        assertEq(uint256(taxToken.swapbacksThisBlock()), 1, "counter == 1 after first swap");
     }
 
     /// @dev Counts `CreatorTaxSwapback` event emissions in the most recent `vm.recordLogs()` window.

--- a/test/tokens/LivoTaxableTokenUniV2.t.sol
+++ b/test/tokens/LivoTaxableTokenUniV2.t.sol
@@ -503,6 +503,55 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         taxToken.rescueTokens(address(0));
     }
 
+    // ─────────────────────────── setTaxBps ───────────────────────────────────────
+
+    function test_setTaxBps_revertsForNonOwners() public {
+        vm.prank(alice);
+        vm.expectRevert(LivoTaxableToken.NotTokenOwner.selector);
+        taxToken.setTaxBps(0, 0);
+
+        // Storage untouched.
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS);
+    }
+
+    function test_setTaxBps_callableByLaunchpadOwner_lowersBoth() public {
+        // Factory-deployed token is ownerless; launchpad.owner() is the only reachable caller.
+        assertEq(taxToken.owner(), address(0));
+        assertEq(launchpad.owner(), admin);
+
+        uint16 newBuy = BUY_BPS - 50;
+        uint16 newSell = SELL_BPS - 100;
+
+        vm.expectEmit(true, true, true, true, address(taxToken));
+        emit LivoTaxableToken.TaxBpsUpdated(newBuy, newSell);
+
+        vm.prank(admin);
+        taxToken.setTaxBps(newBuy, newSell);
+
+        assertEq(taxToken.buyTaxBps(), newBuy);
+        assertEq(taxToken.sellTaxBps(), newSell);
+    }
+
+    function test_setTaxBps_revertsIfBuyIncreases() public {
+        vm.prank(admin);
+        vm.expectRevert(LivoTaxableToken.TaxBpsCanOnlyDecrease.selector);
+        taxToken.setTaxBps(BUY_BPS + 1, SELL_BPS);
+
+        // Storage untouched.
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS);
+    }
+
+    function test_setTaxBps_allowsEqualValues() public {
+        // Keep buy unchanged, lower sell by 1 bps. Equal-on-one-side is a valid call.
+        vm.prank(admin);
+        taxToken.setTaxBps(BUY_BPS, SELL_BPS - 1);
+
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS - 1);
+    }
+
     // ─────────────────────────── Helpers ─────────────────────────────────────────
 
     /// @dev Graduate the test token and seed `buyer` with a large pre-graduation purchase so we


### PR DESCRIPTION
## Summary

Adds owner-only tax decreases on taxable tokens, refactors fee routing to a `receive()`-based push model, gives V2 single-receiver deploys a direct fee path that bypasses the master handler, and tightens the V2 in-token swap-back to satisfy Go+ scanner heuristics.

## Highlights

### `setTaxBps` — owner-only, decrease-only
- New `setTaxBps(newBuyBps, newSellBps)` on `LivoTaxableToken`; callable by token owner or launchpad owner.
- Increases revert with `TaxBpsCanOnlyDecrease`. Emits `TaxBpsUpdated(newBuy, newSell)`.
- Inherited by V2, V4, and sniper-protected variants.

### Fee routing via `receive()`
- `LivoMasterFeeHandler` exposes a `nonReentrant` `receive()` that attributes the incoming ETH to `msg.sender` via an extracted `_depositFees(token)`.
- `LivoToken` ships a new internal `_accrueFees(uint256)` that does a plain ETH `call` to its `feeHandler`; the external `accrueFees()` routes through it and emits `RouteFees(feeHandler, msg.value)`.
- `LivoTaxableToken.rescueTokens` and `LivoTaxableTokenUniV2._swapBack` switched to `_accrueFees`. Failed transfers silently leave ETH on the token; the next swap-back rolls it forward.
- Drops `ILivoMasterFeeHandler` imports from tokens.

### Direct fee-handler path for V2 single-receiver deploys
- V2 taxable deploys with exactly one fee receiver whose `directFeesEnabled` is `true` now bake that receiver's address straight into `token.feeHandler` instead of the master handler. Swap-backs push ETH directly, so scanners no longer see an external call into an unknown contract.
- New `_resolveFeeHandlerForInit` hook on `LivoFactoryAbstract`, overridden by `LivoFactoryUniV2Unified`. `_finalizeCreation` skips `registerFees` when the resolver bypassed the master handler.
- New `DirectSingleFeeReceiver(token, receiver)` factory event.
- `feeHandler` is **immutable** after init on both master-routed and direct-receiver paths (a `setFeeHandler` setter was tried and dropped because it confused the indexer).

### V2 swap-back: per-block counter, Go+-friendly
- `_swapBack` now uses the two-variable counter-reset shape from the reference token that passes Go+'s \"trading cooldown\" heuristic: when `block.number > lastSwapbackBlock`, reset `swapbacksThisBlock` to zero; once it hits `MAX_SWAPBACKS_PER_BLOCK = 2`, further calls in the same block silently no-op (no revert).
- The outer `_update` gate is dropped, so both auto and manual paths share the same per-block guarantee. `SwapbackAlreadyInThisBlock` removed (unreachable).

### Docs / ABIs / scripts
- `docs/events-per-entry-point.md` updated for `TaxBpsUpdated`, the new `receive()` entry point, `DirectSingleFeeReceiver`, and `RouteFees`.
- ABIs regenerated for `LivoFactoryUniV{2,4}Unified`, `ILivoToken`, `ILivoTaxableToken`; the unused `ILivoFeeSplitter` is dropped from `just abis`.
- New scripts: `RedeployAllImpls.s.sol` (impl-only redeploy) and `RedeployTaxTokensAndUpgradeFactories.s.sol`. `justfile` gets sepolia create-token recipes.
- Sepolia + mainnet manifests refreshed (`TAXABLE_TOKEN_V2_IMPL`, `TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL`, `FACTORY_UNIV2_UNIFIED_IMPL`, `MASTER_FEE_HANDLER`).

### Tests
- New `test/factories/LivoFactoryUniV2DirectFeeReceiver.t.sol` covering the direct-receiver path.
- New `test/feeHandlers/LivoMasterFeeHandler.receive.t.sol` covering `receive()` routing, zero-value noop, unregistered sender, and the `nonReentrant` bounce.
- `LivoTaxableTokenUniV2.t.sol` extended for the per-block swap-back counter and immutable `feeHandler`.

## Test plan
- [x] `just fast-test`
- [ ] `just integration-tests` (fork)
- [ ] Sepolia smoke: create V2 token with `directFeesEnabled` single receiver, sell to trigger swap-back, verify ETH lands on the EOA receiver