### PR TITLE
feat(taxes): owner-only setTaxBps (decrease-only) on taxable tokens

### DIFF
--- a/abis/ILivoTaxableToken.json
+++ b/abis/ILivoTaxableToken.json
@@ -369,6 +369,24 @@
   },
   {
     "type": "function",
+    "name": "setTaxBps",
+    "inputs": [
+      {
+        "name": "newBuyTaxBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "newSellTaxBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "totalSupply",
     "inputs": [],
     "outputs": [

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -40,6 +40,7 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 7. [`LivoMasterFeeHandler.claim`](#7-livomasterfeehandlerclaimaddress-tokens)
 8. [`LivoMasterFeeHandler.setShares`](#8-livomasterfeehandlersetsharesaddress-token-feeshare-feeshares)
 9. [Direct-fee behavior](#9-direct-fee-behavior)
+10. [`LivoTaxableToken.setTaxBps`](#10-livotaxabletokensettaxbpsuint16-newbuytaxbps-uint16-newselltaxbps)
 
 ---
 
@@ -244,3 +245,15 @@ For every successful non-zero `depositFees(token)` against a registered config:
 3. Claimable recipients do not emit per-deposit claim events; they accrue through the master handler accumulator and emit `CreatorClaimed` only when they call `claim()`.
 
 Zero-value `depositFees(token)` calls are no-ops and emit no fee events, including for unregistered tokens.
+
+---
+
+## 10. `LivoTaxableToken.setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps)`
+
+Owner-only entry point on both `LivoTaxableTokenUniV2` (and its sniper-protected variant) and `LivoTaxableTokenUniV4` (and its sniper-protected variant). Callable by the token owner OR `launchpad.owner()` — on factory-deployed tokens (`owner == address(0)`) only the launchpad-owner branch is reachable.
+
+The function is decrease-only: `newBuyTaxBps` and `newSellTaxBps` must both be `<= ` their current values, otherwise the call reverts with `TaxBpsCanOnlyDecrease`. Equal values are accepted (no-op for that side). `taxDurationSeconds` and `graduationTimestamp` are untouched.
+
+On success:
+
+1. **`LivoTaxableToken.TaxBpsUpdated`** (`newBuyTaxBps, newSellTaxBps`) — emitted before the storage write. Old values can be reconstructed from the preceding `LivoTaxableTokenInitialized` event at creation time and the chain of any prior `TaxBpsUpdated` events.

--- a/justfile
+++ b/justfile
@@ -20,7 +20,6 @@ abis:
     @jq '.abi' out/ILivoClaims.sol/ILivoClaims.json > abis/ILivoClaims.json
     @jq '.abi' out/LivoFactoryUniV2Unified.sol/LivoFactoryUniV2Unified.json > abis/LivoFactoryUniV2Unified.json
     @jq '.abi' out/LivoFactoryUniV4Unified.sol/LivoFactoryUniV4Unified.json > abis/LivoFactoryUniV4Unified.json
-    @jq '.abi' out/ILivoFeeSplitter.sol/ILivoFeeSplitter.json > abis/ILivoFeeSplitter.json
     @jq '.abi' out/ILivoTaxableToken.sol/ILivoTaxableToken.json > abis/ILivoTaxableToken.json
     @echo "✔ ABIs copied to abis/ directory"
     

--- a/script/RedeployTaxTokensAndUpgradeFactories.s.sol
+++ b/script/RedeployTaxTokensAndUpgradeFactories.s.sol
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {LivoTaxableTokenUniV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {LivoTaxableTokenUniV2SniperProtected} from "src/tokens/LivoTaxableTokenUniV2SniperProtected.sol";
+import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+import {LivoTaxableTokenUniV4SniperProtected} from "src/tokens/LivoTaxableTokenUniV4SniperProtected.sol";
+import {LivoFactoryUniV2Unified} from "src/factories/LivoFactoryUniV2Unified.sol";
+import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
+import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV2} from "src/tokens/LivoTaxableTokenUniV2.sol";
+import {DeploymentAddresses as AddressesFromLivoTaxableTokenV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
+
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @title Redeploy all tax-token implementations and upgrade BOTH unified factory proxies
+/// @notice Wraps up the rollout for the `setTaxBps` feature added to `LivoTaxableToken`.
+///         Both V2 and V4 tax-token families inherit the shared abstract, so all four tax-token
+///         implementations need a fresh bytecode and both unified factories need to be repointed
+///         at the new impls. Non-tax token implementations (`TOKEN_IMPL`,
+///         `TOKEN_SNIPER_PROTECTED_IMPL`) are NOT touched — they don't inherit `LivoTaxableToken`.
+///
+///         Single broadcast, six new deployments + two proxy upgrades:
+///         1. `LivoTaxableTokenUniV2`
+///         2. `LivoTaxableTokenUniV2SniperProtected`
+///         3. `LivoTaxableTokenUniV4`
+///         4. `LivoTaxableTokenUniV4SniperProtected`
+///         5. `LivoFactoryUniV2Unified` impl wired to (1) and (2) plus unchanged non-tax pieces.
+///         6. `LivoFactoryUniV4Unified` impl wired to (3) and (4) plus unchanged non-tax pieces.
+///         7. `upgradeToAndCall(newV2FactoryImpl, "")` on the existing V2 UUPS proxy.
+///         8. `upgradeToAndCall(newV4FactoryImpl, "")` on the existing V4 UUPS proxy.
+///
+///         Proxy addresses are UNCHANGED — launchpad's `whitelistedFactories` entries stay valid;
+///         integrators see no address change. No init data is passed; no new storage was added to
+///         the factories (`setTaxBps` is on the tokens, not the factories).
+///
+///         The broadcaster MUST be the proxy owner on BOTH proxies. If not, `_authorizeUpgrade`
+///         reverts with `OwnableUnauthorizedAccount(broadcaster)` and the whole script reverts.
+///
+///         Pre-broadcast sanity: confirms both V2 and V4 tax-token sources import the right
+///         per-chain `DeploymentAddresses`. Run `just taxtokenaddresses` before deploying to Sepolia.
+///
+///         Post-broadcast: update `TAXABLE_TOKEN_V2_IMPL`, `TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL`,
+///         `TAXABLE_TOKEN_IMPL`, `TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL`, `FACTORY_UNIV2_UNIFIED_IMPL`,
+///         and `FACTORY_UNIV4_UNIFIED_IMPL` in `src/config/deployments.<chain>.sol`, then run
+///         `just export-deployments`.
+///
+/// @dev    Run with:
+///         forge script RedeployTaxTokensAndUpgradeFactories --rpc-url <mainnet|sepolia> \
+///             --verify --account livo.dev --slow --broadcast
+contract RedeployTaxTokensAndUpgradeFactories is Script {
+    /// @dev Per-chain addresses needed to wire the new factory implementations and target the proxy
+    ///      upgrades. Pulled from `src/config/deployments.<chain>.sol`.
+    struct Deps {
+        // Proxies to upgrade
+        address factoryV2Proxy;
+        address factoryV4Proxy;
+        // Shared inputs reused by both fresh factory impls
+        address launchpad;
+        address bondingCurve;
+        address graduatorV2;
+        address graduatorV4;
+        address masterFeeHandler;
+        // Unchanged non-tax token impls — reused as-is when wiring the new factories
+        address tokenImpl;
+        address tokenSniperImpl;
+    }
+
+    /// @dev Addresses emitted by this script (for logging + manifest updates).
+    struct FreshDeployments {
+        address taxTokenV2Impl;
+        address taxTokenV2SniperImpl;
+        address taxTokenV4Impl;
+        address taxTokenV4SniperImpl;
+        address factoryV2Impl;
+        address factoryV4Impl;
+    }
+
+    function _getDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsMainnet.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsMainnet.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                bondingCurve: DeploymentsMainnet.BONDING_CURVE,
+                graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesMainnet.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Mainnet (run `just taxtokenaddresses` only for sepolia)"
+            );
+        } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV2Proxy: DeploymentsSepolia.FACTORY_UNIV2_UNIFIED,
+                factoryV4Proxy: DeploymentsSepolia.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                bondingCurve: DeploymentsSepolia.BONDING_CURVE,
+                graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
+                graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableTokenV2.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV2 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+            require(
+                AddressesFromLivoTaxableTokenV4.BLOCKCHAIN_ID == DeploymentAddressesSepolia.BLOCKCHAIN_ID,
+                "LivoTaxableTokenUniV4 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+        } else {
+            revert("Unsupported chain");
+        }
+
+        require(d.factoryV2Proxy != address(0), "manifest: FACTORY_UNIV2_UNIFIED missing");
+        require(d.factoryV4Proxy != address(0), "manifest: FACTORY_UNIV4_UNIFIED missing");
+        require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
+        require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
+        require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
+        require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
+        require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
+        require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
+    }
+
+    function run() public {
+        Deps memory d = _getDeps();
+        FreshDeployments memory fresh;
+
+        // Catch wrong manifest addresses pointing at non-Livo contracts before we waste deploys.
+        address v2ProxyOwner = LivoFactoryUniV2Unified(d.factoryV2Proxy).owner();
+        address v4ProxyOwner = LivoFactoryUniV4Unified(d.factoryV4Proxy).owner();
+        require(v2ProxyOwner != address(0), "V2 proxy not initialized");
+        require(v4ProxyOwner != address(0), "V4 proxy not initialized");
+        // Same key is expected to own both proxies; this is a soft sanity check, not a hard
+        // protocol invariant.
+        require(v2ProxyOwner == v4ProxyOwner, "V2 and V4 proxy owners differ; review before upgrading");
+
+        console.log("=== Livo Tax-Token Redeploy + Both Factory Upgrades ===");
+        console.log("Chain ID:                ", block.chainid);
+        console.log("Broadcaster:             ", msg.sender);
+        console.log("Required proxy owner:    ", v2ProxyOwner);
+        console.log("V2 factory proxy:        ", d.factoryV2Proxy);
+        console.log("V4 factory proxy:        ", d.factoryV4Proxy);
+        console.log("");
+
+        vm.startBroadcast();
+
+        console.log("| Contract Name                                  | Address |");
+        console.log("| ---------------------------------------------- | --- |");
+
+        // --- Tax token implementations (4) ---
+        fresh.taxTokenV2Impl = address(new LivoTaxableTokenUniV2());
+        console.log("| LivoTaxableTokenUniV2 (new impl)              |", fresh.taxTokenV2Impl);
+
+        fresh.taxTokenV2SniperImpl = address(new LivoTaxableTokenUniV2SniperProtected());
+        console.log("| LivoTaxableTokenUniV2SniperProtected (new)    |", fresh.taxTokenV2SniperImpl);
+
+        fresh.taxTokenV4Impl = address(new LivoTaxableTokenUniV4());
+        console.log("| LivoTaxableTokenUniV4 (new impl)              |", fresh.taxTokenV4Impl);
+
+        fresh.taxTokenV4SniperImpl = address(new LivoTaxableTokenUniV4SniperProtected());
+        console.log("| LivoTaxableTokenUniV4SniperProtected (new)    |", fresh.taxTokenV4SniperImpl);
+
+        // --- Factory implementations (2) wired to the fresh tax-token impls + unchanged rest ---
+        fresh.factoryV2Impl = address(
+            new LivoFactoryUniV2Unified(
+                d.launchpad,
+                d.tokenImpl,
+                d.tokenSniperImpl,
+                fresh.taxTokenV2Impl,
+                fresh.taxTokenV2SniperImpl,
+                d.bondingCurve,
+                d.graduatorV2,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV2Unified (new impl)            |", fresh.factoryV2Impl);
+
+        fresh.factoryV4Impl = address(
+            new LivoFactoryUniV4Unified(
+                d.launchpad,
+                d.tokenImpl,
+                d.tokenSniperImpl,
+                fresh.taxTokenV4Impl,
+                fresh.taxTokenV4SniperImpl,
+                d.bondingCurve,
+                d.graduatorV4,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV4Unified (new impl)            |", fresh.factoryV4Impl);
+
+        // --- Proxy upgrades (2) ---
+        UUPSUpgradeable(d.factoryV2Proxy).upgradeToAndCall(fresh.factoryV2Impl, "");
+        console.log("| V2 proxy upgraded to                          |", fresh.factoryV2Impl);
+
+        UUPSUpgradeable(d.factoryV4Proxy).upgradeToAndCall(fresh.factoryV4Impl, "");
+        console.log("| V4 proxy upgraded to                          |", fresh.factoryV4Impl);
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Redeploy Complete ===");
+        console.log("Proxy addresses are UNCHANGED - no launchpad whitelisting or integrator action needed.");
+        console.log("Update the per-chain manifest with these addresses, then run `just export-deployments`:");
+        console.log("  TAXABLE_TOKEN_V2_IMPL                  :", fresh.taxTokenV2Impl);
+        console.log("  TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL :", fresh.taxTokenV2SniperImpl);
+        console.log("  TAXABLE_TOKEN_IMPL                     :", fresh.taxTokenV4Impl);
+        console.log("  TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL    :", fresh.taxTokenV4SniperImpl);
+        console.log("  FACTORY_UNIV2_UNIFIED_IMPL             :", fresh.factoryV2Impl);
+        console.log("  FACTORY_UNIV4_UNIFIED_IMPL             :", fresh.factoryV4Impl);
+    }
+}

--- a/src/interfaces/ILivoTaxableToken.sol
+++ b/src/interfaces/ILivoTaxableToken.sol
@@ -26,6 +26,10 @@ interface ILivoTaxableToken is ILivoToken {
     /// @notice Initializes a taxable-token clone. Used by the factory to dispatch into either V2
     ///         or V4 concrete tax-token implementations through a single shared type.
     function initialize(ILivoToken.InitializeParams memory params, TaxConfigInit memory taxCfg) external;
+
+    /// @notice Owner-only setter for `buyTaxBps` / `sellTaxBps`. Currently enforces decrease-only —
+    ///         attempts to raise either rate revert.
+    function setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps) external;
 }
 
 /// @title ILivoTaxableTokenSniperProtected

--- a/src/tokens/LivoTaxableToken.sol
+++ b/src/tokens/LivoTaxableToken.sol
@@ -22,10 +22,12 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
 
     //////////////////////// potentially immutable //////////////////
 
-    /// @notice Buy tax rate in basis points (set during initialization, cannot be changed)
+    /// @notice Buy tax rate in basis points. Set during initialization; the owner can lower it later
+    ///         via `setTaxBps` (decrease-only — increases revert).
     uint16 public buyTaxBps;
 
-    /// @notice Sell tax rate in basis points (set during initialization, cannot be changed)
+    /// @notice Sell tax rate in basis points. Set during initialization; the owner can lower it later
+    ///         via `setTaxBps` (decrease-only — increases revert).
     uint16 public sellTaxBps;
 
     /// @notice Duration in seconds after graduation during which taxes apply (set during initialization, cannot be changed)
@@ -41,10 +43,16 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
     /// @notice Emitted once during init with the dev-supplied tax config.
     event LivoTaxableTokenInitialized(uint16 buyTaxBps, uint16 sellTaxBps, uint40 taxDurationSeconds);
 
+    /// @notice Emitted whenever `setTaxBps` successfully updates the buy/sell tax rates. Only the
+    ///         new values are carried; indexers can resolve old values from the prior
+    ///         `LivoTaxableTokenInitialized` event or the most recent prior `TaxBpsUpdated`.
+    event TaxBpsUpdated(uint16 newBuyTaxBps, uint16 newSellTaxBps);
+
     //////////////////////// Errors //////////////////////
 
     error NotTokenOwner();
     error CannotRescueSelfToken();
+    error TaxBpsCanOnlyDecrease();
 
     //////////////////////////////////////////////////////
 
@@ -91,6 +99,27 @@ abstract contract LivoTaxableToken is LivoToken, ILivoTaxableToken {
         } else {
             IERC20(token).safeTransfer(owner, IERC20(token).balanceOf(address(this)));
         }
+    }
+
+    /// @notice Updates `buyTaxBps` and/or `sellTaxBps`. Today this is decrease-only — any attempt
+    ///         to raise either rate reverts with `TaxBpsCanOnlyDecrease`. Passing a value equal to
+    ///         the current one is allowed (no-op for that side). `taxDurationSeconds` and
+    ///         `graduationTimestamp` are untouched.
+    /// @dev The function name is intentionally generic (`setTaxBps`) even though the body enforces
+    ///      a narrower decrease-only rule. This keeps the ABI stable if the policy is ever relaxed.
+    /// @dev Callable by the token owner OR the launchpad owner — same dual-auth pattern as
+    ///      `swapBack` / `rescueTokens`. On factory-deployed tokens (`owner == address(0)`) only
+    ///      the launchpad-owner branch is reachable, which is intentional.
+    /// @param newBuyTaxBps New buy tax rate in basis points. Must be `<= buyTaxBps`.
+    /// @param newSellTaxBps New sell tax rate in basis points. Must be `<= sellTaxBps`.
+    function setTaxBps(uint16 newBuyTaxBps, uint16 newSellTaxBps) external {
+        require(msg.sender == owner || msg.sender == launchpad.owner(), NotTokenOwner());
+        require(newBuyTaxBps <= buyTaxBps && newSellTaxBps <= sellTaxBps, TaxBpsCanOnlyDecrease());
+
+        emit TaxBpsUpdated(newBuyTaxBps, newSellTaxBps);
+
+        buyTaxBps = newBuyTaxBps;
+        sellTaxBps = newSellTaxBps;
     }
 
     //////////////////////// VIEW FUNCTIONS //////////////////////

--- a/test/tokens/LivoTaxableTokenUniV2.t.sol
+++ b/test/tokens/LivoTaxableTokenUniV2.t.sol
@@ -503,6 +503,55 @@ contract LivoTaxableTokenUniV2Tests is LaunchpadBaseTestsWithUniv2Graduator, V2S
         taxToken.rescueTokens(address(0));
     }
 
+    // ─────────────────────────── setTaxBps ───────────────────────────────────────
+
+    function test_setTaxBps_revertsForNonOwners() public {
+        vm.prank(alice);
+        vm.expectRevert(LivoTaxableToken.NotTokenOwner.selector);
+        taxToken.setTaxBps(0, 0);
+
+        // Storage untouched.
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS);
+    }
+
+    function test_setTaxBps_callableByLaunchpadOwner_lowersBoth() public {
+        // Factory-deployed token is ownerless; launchpad.owner() is the only reachable caller.
+        assertEq(taxToken.owner(), address(0));
+        assertEq(launchpad.owner(), admin);
+
+        uint16 newBuy = BUY_BPS - 50;
+        uint16 newSell = SELL_BPS - 100;
+
+        vm.expectEmit(true, true, true, true, address(taxToken));
+        emit LivoTaxableToken.TaxBpsUpdated(newBuy, newSell);
+
+        vm.prank(admin);
+        taxToken.setTaxBps(newBuy, newSell);
+
+        assertEq(taxToken.buyTaxBps(), newBuy);
+        assertEq(taxToken.sellTaxBps(), newSell);
+    }
+
+    function test_setTaxBps_revertsIfBuyIncreases() public {
+        vm.prank(admin);
+        vm.expectRevert(LivoTaxableToken.TaxBpsCanOnlyDecrease.selector);
+        taxToken.setTaxBps(BUY_BPS + 1, SELL_BPS);
+
+        // Storage untouched.
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS);
+    }
+
+    function test_setTaxBps_allowsEqualValues() public {
+        // Keep buy unchanged, lower sell by 1 bps. Equal-on-one-side is a valid call.
+        vm.prank(admin);
+        taxToken.setTaxBps(BUY_BPS, SELL_BPS - 1);
+
+        assertEq(taxToken.buyTaxBps(), BUY_BPS);
+        assertEq(taxToken.sellTaxBps(), SELL_BPS - 1);
+    }
+
     // ─────────────────────────── Helpers ─────────────────────────────────────────
 
     /// @dev Graduate the test token and seed `buyer` with a large pre-graduation purchase so we


### PR DESCRIPTION
Adds setTaxBps(newBuy, newSell) on the shared LivoTaxableToken abstract
so the token owner or launchpad owner can lower buy/sell tax rates
post-init. Increases revert with TaxBpsCanOnlyDecrease; emits
TaxBpsUpdated(newBuy, newSell). Picked up by both V2 and V4 (and
sniper-protected) variants via inheritance.

Also adds a redeploy script for all four tax-token impls + both
unified factory proxy upgrades, drops the unused ILivoFeeSplitter ABI
from `just abis`, and documents the new event in events-per-entry-point.md.
