### PR TITLE
feat(factory-v4): support 0.5% LP-fee variant via second graduator

### DIFF
--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -10,8 +10,10 @@
 | ConstantProductBondingCurve                  | `0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23` |
 | LivoGraduatorUniswapV2                       | `0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC` |
 | LivoGraduatorUniswapV4                       | `0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944` |
+| LivoGraduatorUniswapV4 (0.5% hook)           | _(not deployed)_                             |
 | LivoMasterFeeHandler                         | `0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC` |
 | LivoSwapHook                                 | `0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc` |
+| LivoSwapHook (0.5%)                          | `0x068241d20c59980AbEAeDED990d2441F05f5C0Cc` |
 | LivoQuoter                                   | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
 | LivoToken (impl)                             | `0x0319E8C68cf293271f9C3Ad6C476DAe6Be40CdBD` |
 | LivoTaxableTokenUniV4 (impl)                 | `0xf68Ea9a3522647C58d7c77edE156cAA0930a7101` |

--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23` |
 | LivoGraduatorUniswapV2                       | `0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC` |
 | LivoGraduatorUniswapV4                       | `0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944` |
-| LivoGraduatorUniswapV4 (0.5% hook)           | _(not deployed)_                             |
+| LivoGraduatorUniswapV4 (0.5% hook)           | `0xB2B7157e51d592356c5E7706F8371e2f0a425B7e` |
 | LivoMasterFeeHandler                         | `0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC` |
 | LivoSwapHook                                 | `0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc` |
 | LivoSwapHook (0.5%)                          | `0x068241d20c59980AbEAeDED990d2441F05f5C0Cc` |
@@ -24,7 +24,7 @@
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
 | LivoFactoryUniV2Unified (impl)               | `0xF470512f22bF50224e5Ea96673da1C1Fbb20018a` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0xBB0EBb375e9dc06DE3eC0d6410606Cb3DAc6737b` |
+| LivoFactoryUniV4Unified (impl)               | `0xc28b19Fa83d025c8C76E44D8010d8e2A100029BD` |
 
 ## Accounts
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -10,8 +10,10 @@
 | ConstantProductBondingCurve                  | `0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5` |
 | LivoGraduatorUniswapV2                       | `0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691` |
 | LivoGraduatorUniswapV4                       | `0x85fE2051413a4b80b904f05841d1142FeF7f789c` |
+| LivoGraduatorUniswapV4 (0.5% hook)           | _(not deployed)_                             |
 | LivoMasterFeeHandler                         | `0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f` |
 | LivoSwapHook                                 | `0x0591a87D3a56797812C4DA164C1B005c545400Cc` |
+| LivoSwapHook (0.5%)                          | `0xC04Bb5bA43795330e54efaC7244ce40318FD80cc` |
 | LivoQuoter                                   | `0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438` |
 | LivoToken (impl)                             | `0x9e11191aC22b1C25A64e8de86dd9Db098a343e01` |
 | LivoTaxableTokenUniV4 (impl)                 | `0xd9F88d337CF88126850d150651CFbCE5E5299f08` |

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -10,7 +10,7 @@
 | ConstantProductBondingCurve                  | `0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5` |
 | LivoGraduatorUniswapV2                       | `0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691` |
 | LivoGraduatorUniswapV4                       | `0x85fE2051413a4b80b904f05841d1142FeF7f789c` |
-| LivoGraduatorUniswapV4 (0.5% hook)           | _(not deployed)_                             |
+| LivoGraduatorUniswapV4 (0.5% hook)           | `0x3d6398E54549c5a8b88071C180509B41043Df7Da` |
 | LivoMasterFeeHandler                         | `0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f` |
 | LivoSwapHook                                 | `0x0591a87D3a56797812C4DA164C1B005c545400Cc` |
 | LivoSwapHook (0.5%)                          | `0xC04Bb5bA43795330e54efaC7244ce40318FD80cc` |
@@ -24,7 +24,7 @@
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
 | LivoFactoryUniV2Unified (impl)               | `0xdf507841a9Ba153e244767CcFE062Ba0DF7bCf40` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0x3330a265A1bF168234cA144D36e0c70Dc239250c` |
+| LivoFactoryUniV4Unified (impl)               | `0x1285E96Fee2Fd4B1C4bee0b27ada91A5AC437bD7` |
 
 ## Accounts
 

--- a/script/DeployUniV4Graduator0p5.s.sol
+++ b/script/DeployUniV4Graduator0p5.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script} from "lib/forge-std/src/Script.sol";
+import {console} from "lib/forge-std/src/console.sol";
+import {LivoGraduatorUniswapV4} from "src/graduators/LivoGraduatorUniswapV4.sol";
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @notice Deploys a `LivoGraduatorUniswapV4` instance wired to `SWAP_HOOK_0P5` (50-bps LP fee).
+/// @dev    The existing `GRADUATOR_UNIV4` (paired with the 100-bps hook) is untouched — only the
+///         0.5% counterpart is new. After broadcasting, paste the printed address into
+///         `GRADUATOR_UNIV4_0P5` in the per-chain manifest and run `just export-deployments`. From
+///         there the existing factory deploy/upgrade scripts will pick the new graduator up
+///         automatically.
+///
+/// Usage (dry run):  forge script DeployUniV4Graduator0p5 --rpc-url <mainnet|sepolia> --account livo.dev
+/// Usage (deploy):   forge script DeployUniV4Graduator0p5 --rpc-url <mainnet|sepolia> --account livo.dev --slow --broadcast --verify
+contract DeployUniV4Graduator0p5 is Script {
+    struct Deps {
+        address launchpad;
+        address poolManager;
+        address positionManager;
+        address permit2;
+        address hook;
+    }
+
+    function run() external {
+        Deps memory d = _resolveDeps();
+
+        console.log("=== Deploy LivoGraduatorUniswapV4 (0.5%) ===");
+        console.log("Chain ID:        %d", block.chainid);
+        console.log("Launchpad:       %s", d.launchpad);
+        console.log("PoolManager:     %s", d.poolManager);
+        console.log("PositionManager: %s", d.positionManager);
+        console.log("Permit2:         %s", d.permit2);
+        console.log("Hook (50 bps):   %s", d.hook);
+
+        vm.startBroadcast();
+        LivoGraduatorUniswapV4 graduator =
+            new LivoGraduatorUniswapV4(d.launchpad, d.poolManager, d.positionManager, d.permit2, d.hook);
+        vm.stopBroadcast();
+
+        require(graduator.HOOK_ADDRESS() == d.hook, "graduator hook mismatch");
+
+        console.log("=== Deployed ===");
+        console.log("LivoGraduatorUniswapV4 (0.5%%): %s", address(graduator));
+        console.log("");
+        console.log(
+            "Next: paste this address into GRADUATOR_UNIV4_0P5 in src/config/deployments.%s.sol",
+            block.chainid == 1 ? "mainnet" : "sepolia"
+        );
+        console.log("Then: `just export-deployments` and re-run UpgradeUnifiedFactories.");
+    }
+
+    function _resolveDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentAddressesMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                poolManager: DeploymentAddressesMainnet.UNIV4_POOL_MANAGER,
+                positionManager: DeploymentAddressesMainnet.UNIV4_POSITION_MANAGER,
+                permit2: DeploymentAddressesMainnet.PERMIT2,
+                hook: DeploymentsMainnet.SWAP_HOOK_0P5
+            });
+        } else if (block.chainid == DeploymentAddressesSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                poolManager: DeploymentAddressesSepolia.UNIV4_POOL_MANAGER,
+                positionManager: DeploymentAddressesSepolia.UNIV4_POSITION_MANAGER,
+                permit2: DeploymentAddressesSepolia.PERMIT2,
+                hook: DeploymentsSepolia.SWAP_HOOK_0P5
+            });
+        } else {
+            revert("Unsupported chain ID");
+        }
+
+        require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
+        require(d.hook != address(0), "manifest: SWAP_HOOK_0P5 missing");
+    }
+}

--- a/script/DeploymentsUnifiedFactories.s.sol
+++ b/script/DeploymentsUnifiedFactories.s.sol
@@ -41,6 +41,7 @@ contract DeploymentsUnifiedFactories is Script {
         address bondingCurve;
         address graduatorV2;
         address graduatorV4;
+        address graduatorV4_0p5;
         address masterFeeHandler;
         address tokenImpl;
         address tokenSniperImpl;
@@ -68,6 +69,7 @@ contract DeploymentsUnifiedFactories is Script {
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL,
@@ -86,6 +88,7 @@ contract DeploymentsUnifiedFactories is Script {
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL,
@@ -107,6 +110,7 @@ contract DeploymentsUnifiedFactories is Script {
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
         require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing");
         require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
         require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
         require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
@@ -158,6 +162,7 @@ contract DeploymentsUnifiedFactories is Script {
                 d.taxTokenSniperImpl,
                 d.bondingCurve,
                 d.graduatorV4,
+                d.graduatorV4_0p5,
                 d.masterFeeHandler
             )
         );

--- a/script/ExportDeployments.s.sol
+++ b/script/ExportDeployments.s.sol
@@ -39,8 +39,10 @@ contract ExportDeployments is Script {
         s = string.concat(s, _row("ConstantProductBondingCurve", DeploymentsMainnet.BONDING_CURVE));
         s = string.concat(s, _row("LivoGraduatorUniswapV2", DeploymentsMainnet.GRADUATOR_UNIV2));
         s = string.concat(s, _row("LivoGraduatorUniswapV4", DeploymentsMainnet.GRADUATOR_UNIV4));
+        s = string.concat(s, _row("LivoGraduatorUniswapV4 (0.5% hook)", DeploymentsMainnet.GRADUATOR_UNIV4_0P5));
         s = string.concat(s, _row("LivoMasterFeeHandler", DeploymentsMainnet.MASTER_FEE_HANDLER));
         s = string.concat(s, _row("LivoSwapHook", DeploymentsMainnet.SWAP_HOOK));
+        s = string.concat(s, _row("LivoSwapHook (0.5%)", DeploymentsMainnet.SWAP_HOOK_0P5));
         s = string.concat(s, _row("LivoQuoter", DeploymentsMainnet.QUOTER));
         s = string.concat(s, _row("LivoToken (impl)", DeploymentsMainnet.TOKEN_IMPL));
         s = string.concat(s, _row("LivoTaxableTokenUniV4 (impl)", DeploymentsMainnet.TAXABLE_TOKEN_IMPL));
@@ -86,8 +88,10 @@ contract ExportDeployments is Script {
         s = string.concat(s, _row("ConstantProductBondingCurve", DeploymentsSepolia.BONDING_CURVE));
         s = string.concat(s, _row("LivoGraduatorUniswapV2", DeploymentsSepolia.GRADUATOR_UNIV2));
         s = string.concat(s, _row("LivoGraduatorUniswapV4", DeploymentsSepolia.GRADUATOR_UNIV4));
+        s = string.concat(s, _row("LivoGraduatorUniswapV4 (0.5% hook)", DeploymentsSepolia.GRADUATOR_UNIV4_0P5));
         s = string.concat(s, _row("LivoMasterFeeHandler", DeploymentsSepolia.MASTER_FEE_HANDLER));
         s = string.concat(s, _row("LivoSwapHook", DeploymentsSepolia.SWAP_HOOK));
+        s = string.concat(s, _row("LivoSwapHook (0.5%)", DeploymentsSepolia.SWAP_HOOK_0P5));
         s = string.concat(s, _row("LivoQuoter", DeploymentsSepolia.QUOTER));
         s = string.concat(s, _row("LivoToken (impl)", DeploymentsSepolia.TOKEN_IMPL));
         s = string.concat(s, _row("LivoTaxableTokenUniV4 (impl)", DeploymentsSepolia.TAXABLE_TOKEN_IMPL));

--- a/script/RedeployAllTokensAndUpgradeFactories.s.sol
+++ b/script/RedeployAllTokensAndUpgradeFactories.s.sol
@@ -71,6 +71,7 @@ contract RedeployAllTokensAndUpgradeFactories is Script {
         address bondingCurve;
         address graduatorV2;
         address graduatorV4;
+        address graduatorV4_0p5;
         address masterFeeHandler;
     }
 
@@ -95,6 +96,7 @@ contract RedeployAllTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER
             });
             require(
@@ -113,6 +115,7 @@ contract RedeployAllTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER
             });
             require(
@@ -133,6 +136,7 @@ contract RedeployAllTokensAndUpgradeFactories is Script {
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
         require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing");
         require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
     }
 
@@ -203,6 +207,7 @@ contract RedeployAllTokensAndUpgradeFactories is Script {
                 fresh.taxTokenV4SniperImpl,
                 d.bondingCurve,
                 d.graduatorV4,
+                d.graduatorV4_0p5,
                 d.masterFeeHandler
             )
         );

--- a/script/RedeploySniperTokensAndUpgradeFactories.s.sol
+++ b/script/RedeploySniperTokensAndUpgradeFactories.s.sol
@@ -64,6 +64,7 @@ contract RedeploySniperTokensAndUpgradeFactories is Script {
         address bondingCurve;
         address graduatorV2;
         address graduatorV4;
+        address graduatorV4_0p5;
         address masterFeeHandler;
         address tokenImpl;
         address taxTokenImpl;
@@ -88,6 +89,7 @@ contract RedeploySniperTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
                 taxTokenImpl: DeploymentsMainnet.TAXABLE_TOKEN_IMPL,
@@ -109,6 +111,7 @@ contract RedeploySniperTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
                 taxTokenImpl: DeploymentsSepolia.TAXABLE_TOKEN_IMPL,
@@ -132,6 +135,7 @@ contract RedeploySniperTokensAndUpgradeFactories is Script {
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
         require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing");
         require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
         require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
         require(d.taxTokenImpl != address(0), "manifest: TAXABLE_TOKEN_IMPL missing");
@@ -195,6 +199,7 @@ contract RedeploySniperTokensAndUpgradeFactories is Script {
                 fresh.taxTokenV4SniperImpl,
                 d.bondingCurve,
                 d.graduatorV4,
+                d.graduatorV4_0p5,
                 d.masterFeeHandler
             )
         );

--- a/script/RedeployTaxTokensAndUpgradeFactories.s.sol
+++ b/script/RedeployTaxTokensAndUpgradeFactories.s.sol
@@ -65,6 +65,7 @@ contract RedeployTaxTokensAndUpgradeFactories is Script {
         address bondingCurve;
         address graduatorV2;
         address graduatorV4;
+        address graduatorV4_0p5;
         address masterFeeHandler;
         // Unchanged non-tax token impls — reused as-is when wiring the new factories
         address tokenImpl;
@@ -90,6 +91,7 @@ contract RedeployTaxTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL
@@ -110,6 +112,7 @@ contract RedeployTaxTokensAndUpgradeFactories is Script {
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL
@@ -132,6 +135,7 @@ contract RedeployTaxTokensAndUpgradeFactories is Script {
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
         require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing");
         require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
         require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
         require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
@@ -200,6 +204,7 @@ contract RedeployTaxTokensAndUpgradeFactories is Script {
                 fresh.taxTokenV4SniperImpl,
                 d.bondingCurve,
                 d.graduatorV4,
+                d.graduatorV4_0p5,
                 d.masterFeeHandler
             )
         );

--- a/script/UpgradeUniV4UnifiedFactory.s.sol
+++ b/script/UpgradeUniV4UnifiedFactory.s.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
+import {UUPSUpgradeable} from "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+
+import {DeploymentAddresses as AddressesFromLivoTaxableToken} from "src/tokens/LivoTaxableTokenUniV4.sol";
+
+import {DeploymentAddressesMainnet, DeploymentAddressesSepolia} from "src/config/DeploymentAddresses.sol";
+import {DeploymentsMainnet} from "src/config/deployments.mainnet.sol";
+import {DeploymentsSepolia} from "src/config/deployments.sepolia.sol";
+
+/// @title Upgrade the LivoFactoryUniV4Unified proxy to the dual-graduator implementation
+/// @notice Rolls out the 0.5% LP-fee variant: the new `LivoFactoryUniV4Unified` constructor now
+///         takes both `graduator` (100 bps) and `graduator0p5` (50 bps) and routes `createToken`
+///         calls between them based on `UniV4Configs.lpFeeBps`. Only the V4 unified factory proxy
+///         is touched — the V2 unified factory is untouched, and the launchpad's
+///         `whitelistedFactories` mapping is unchanged because the proxy address doesn't move.
+///
+///         Single broadcast:
+///         1. deploys a fresh `LivoFactoryUniV4Unified` implementation wired to the addresses in
+///            the per-chain manifest (`src/config/deployments.{mainnet,sepolia}.sol`), including
+///            the new `GRADUATOR_UNIV4_0P5`.
+///         2. calls `upgradeToAndCall(newImpl, "")` on the existing V4 factory proxy.
+///
+///         No init data is passed — no new storage slots are added by this implementation
+///         (`GRADUATOR_0P5` is an immutable, baked into the bytecode).
+///
+///         The broadcaster MUST be the proxy owner. If not, `_authorizeUpgrade` reverts with
+///         `OwnableUnauthorizedAccount(broadcaster)` and no state changes.
+///
+///         Pre-flight: `GRADUATOR_UNIV4_0P5` must already be deployed and recorded in the manifest.
+///         Use `script/DeployUniV4Graduator0p5.s.sol` first if it's still `address(0)`.
+///
+///         Post-broadcast: update `FACTORY_UNIV4_UNIFIED_IMPL` in `src/config/deployments.<chain>.sol`,
+///         then run `just export-deployments`.
+///
+/// @dev    Run with:
+///         forge script UpgradeUniV4UnifiedFactory --rpc-url <mainnet|sepolia> \
+///             --verify --account livo.dev --slow --broadcast
+contract UpgradeUniV4UnifiedFactory is Script {
+    /// @dev Per-chain addresses pulled from the manifest. `factoryV4Proxy` is the existing UUPS
+    ///      proxy whose impl we're swapping. Everything else is wired into the new implementation
+    ///      as immutables.
+    struct Deps {
+        address factoryV4Proxy;
+        address launchpad;
+        address bondingCurve;
+        address graduatorV4;
+        address graduatorV4_0p5;
+        address masterFeeHandler;
+        address tokenImpl;
+        address tokenSniperImpl;
+        address taxTokenImpl;
+        address taxTokenSniperImpl;
+    }
+
+    function _getDeps() internal view returns (Deps memory d) {
+        if (block.chainid == DeploymentsMainnet.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV4Proxy: DeploymentsMainnet.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsMainnet.LAUNCHPAD,
+                bondingCurve: DeploymentsMainnet.BONDING_CURVE,
+                graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
+                masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL,
+                taxTokenImpl: DeploymentsMainnet.TAXABLE_TOKEN_IMPL,
+                taxTokenSniperImpl: DeploymentsMainnet.TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableToken.UNIV4_POOL_MANAGER == DeploymentAddressesMainnet.UNIV4_POOL_MANAGER,
+                "LivoTaxableTokenUniV4 import is not Mainnet"
+            );
+        } else if (block.chainid == DeploymentsSepolia.BLOCKCHAIN_ID) {
+            d = Deps({
+                factoryV4Proxy: DeploymentsSepolia.FACTORY_UNIV4_UNIFIED,
+                launchpad: DeploymentsSepolia.LAUNCHPAD,
+                bondingCurve: DeploymentsSepolia.BONDING_CURVE,
+                graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
+                masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
+                tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
+                tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL,
+                taxTokenImpl: DeploymentsSepolia.TAXABLE_TOKEN_IMPL,
+                taxTokenSniperImpl: DeploymentsSepolia.TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL
+            });
+            require(
+                AddressesFromLivoTaxableToken.UNIV4_POOL_MANAGER == DeploymentAddressesSepolia.UNIV4_POOL_MANAGER,
+                "LivoTaxableTokenUniV4 import is not Sepolia (run `just taxtokenaddresses`)"
+            );
+        } else {
+            revert("Unsupported chain");
+        }
+
+        require(d.factoryV4Proxy != address(0), "manifest: FACTORY_UNIV4_UNIFIED missing");
+        require(d.launchpad != address(0), "manifest: LAUNCHPAD missing");
+        require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
+        require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing (deploy it first)");
+        require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
+        require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
+        require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
+        require(d.taxTokenImpl != address(0), "manifest: TAXABLE_TOKEN_IMPL missing");
+        require(d.taxTokenSniperImpl != address(0), "manifest: TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL missing");
+    }
+
+    function run() public {
+        Deps memory d = _getDeps();
+
+        // Sanity: confirm the proxy is responsive and initialized. Catches a wrong manifest
+        // address pointing at a non-Livo contract before we waste a deploy.
+        address proxyOwner = LivoFactoryUniV4Unified(d.factoryV4Proxy).owner();
+        require(proxyOwner != address(0), "V4 proxy not initialized");
+
+        console.log("=== Livo UniV4 Unified Factory Upgrade (dual-graduator routing) ===");
+        console.log("Chain ID:                ", block.chainid);
+        console.log("Broadcaster:             ", msg.sender);
+        console.log("Required proxy owner:    ", proxyOwner);
+        console.log("V4 factory proxy:        ", d.factoryV4Proxy);
+        console.log("Graduator (100 bps):     ", d.graduatorV4);
+        console.log("Graduator (50 bps):      ", d.graduatorV4_0p5);
+        console.log("");
+
+        vm.startBroadcast();
+
+        console.log("| Contract Name                          | Address |");
+        console.log("| -------------------------------------- | --- |");
+
+        address factoryV4Impl = address(
+            new LivoFactoryUniV4Unified(
+                d.launchpad,
+                d.tokenImpl,
+                d.tokenSniperImpl,
+                d.taxTokenImpl,
+                d.taxTokenSniperImpl,
+                d.bondingCurve,
+                d.graduatorV4,
+                d.graduatorV4_0p5,
+                d.masterFeeHandler
+            )
+        );
+        console.log("| LivoFactoryUniV4Unified (new impl)    |", factoryV4Impl);
+
+        UUPSUpgradeable(d.factoryV4Proxy).upgradeToAndCall(factoryV4Impl, "");
+        console.log("| V4 proxy upgraded to                  |", factoryV4Impl);
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Upgrade Complete ===");
+        console.log("Proxy address is UNCHANGED - no launchpad whitelisting or integrator action needed.");
+        console.log("Update the per-chain manifest, then run `just export-deployments`:");
+        console.log("  FACTORY_UNIV4_UNIFIED_IMPL :", factoryV4Impl);
+    }
+}

--- a/script/UpgradeUnifiedFactories.s.sol
+++ b/script/UpgradeUnifiedFactories.s.sol
@@ -44,6 +44,7 @@ contract UpgradeUnifiedFactories is Script {
         address bondingCurve;
         address graduatorV2;
         address graduatorV4;
+        address graduatorV4_0p5;
         address masterFeeHandler;
         address tokenImpl;
         address tokenSniperImpl;
@@ -68,6 +69,7 @@ contract UpgradeUnifiedFactories is Script {
                 bondingCurve: DeploymentsMainnet.BONDING_CURVE,
                 graduatorV2: DeploymentsMainnet.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsMainnet.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsMainnet.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsMainnet.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsMainnet.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsMainnet.TOKEN_SNIPER_PROTECTED_IMPL,
@@ -88,6 +90,7 @@ contract UpgradeUnifiedFactories is Script {
                 bondingCurve: DeploymentsSepolia.BONDING_CURVE,
                 graduatorV2: DeploymentsSepolia.GRADUATOR_UNIV2,
                 graduatorV4: DeploymentsSepolia.GRADUATOR_UNIV4,
+                graduatorV4_0p5: DeploymentsSepolia.GRADUATOR_UNIV4_0P5,
                 masterFeeHandler: DeploymentsSepolia.MASTER_FEE_HANDLER,
                 tokenImpl: DeploymentsSepolia.TOKEN_IMPL,
                 tokenSniperImpl: DeploymentsSepolia.TOKEN_SNIPER_PROTECTED_IMPL,
@@ -111,6 +114,7 @@ contract UpgradeUnifiedFactories is Script {
         require(d.bondingCurve != address(0), "manifest: BONDING_CURVE missing");
         require(d.graduatorV2 != address(0), "manifest: GRADUATOR_UNIV2 missing");
         require(d.graduatorV4 != address(0), "manifest: GRADUATOR_UNIV4 missing");
+        require(d.graduatorV4_0p5 != address(0), "manifest: GRADUATOR_UNIV4_0P5 missing");
         require(d.masterFeeHandler != address(0), "manifest: MASTER_FEE_HANDLER missing");
         require(d.tokenImpl != address(0), "manifest: TOKEN_IMPL missing");
         require(d.tokenSniperImpl != address(0), "manifest: TOKEN_SNIPER_PROTECTED_IMPL missing");
@@ -172,6 +176,7 @@ contract UpgradeUnifiedFactories is Script {
                 d.taxTokenSniperImpl,
                 d.bondingCurve,
                 d.graduatorV4,
+                d.graduatorV4_0p5,
                 d.masterFeeHandler
             )
         );

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -15,6 +15,8 @@ library DeploymentsMainnet {
     address internal constant BONDING_CURVE = 0x3faCE9330730fB6f2a9Bb5994cDC882F21ee0A23;
     address internal constant GRADUATOR_UNIV2 = 0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC;
     address internal constant GRADUATOR_UNIV4 = 0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944;
+    /// @notice V4 graduator paired with the 50-bps `SWAP_HOOK_0P5` variant. Update after deploying.
+    address internal constant GRADUATOR_UNIV4_0P5 = address(0);
     address internal constant MASTER_FEE_HANDLER = 0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC;
 
     address internal constant SWAP_HOOK = 0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc;

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -16,7 +16,7 @@ library DeploymentsMainnet {
     address internal constant GRADUATOR_UNIV2 = 0x7cC6AC0aa4130A5dFe7d00C85645f6Cd2bd7e1cC;
     address internal constant GRADUATOR_UNIV4 = 0x3b6f7a54F3225B9D1B546E0138a2e3D140D89944;
     /// @notice V4 graduator paired with the 50-bps `SWAP_HOOK_0P5` variant. Update after deploying.
-    address internal constant GRADUATOR_UNIV4_0P5 = address(0);
+    address internal constant GRADUATOR_UNIV4_0P5 = 0xB2B7157e51d592356c5E7706F8371e2f0a425B7e;
     address internal constant MASTER_FEE_HANDLER = 0x6F0f4F70a403B9191D6adf2C10750Ab8436345cC;
 
     address internal constant SWAP_HOOK = 0x627FA6F76FA96b10BAe1B6Fba280A3c9264500Cc;
@@ -44,7 +44,7 @@ library DeploymentsMainnet {
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
     address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xF470512f22bF50224e5Ea96673da1C1Fbb20018a;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xBB0EBb375e9dc06DE3eC0d6410606Cb3DAc6737b;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xc28b19Fa83d025c8C76E44D8010d8e2A100029BD;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -17,7 +17,7 @@ library DeploymentsSepolia {
     address internal constant GRADUATOR_UNIV2 = 0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691;
     address internal constant GRADUATOR_UNIV4 = 0x85fE2051413a4b80b904f05841d1142FeF7f789c;
     /// @notice V4 graduator paired with the 50-bps `SWAP_HOOK_0P5` variant. Update after deploying.
-    address internal constant GRADUATOR_UNIV4_0P5 = address(0);
+    address internal constant GRADUATOR_UNIV4_0P5 = 0x3d6398E54549c5a8b88071C180509B41043Df7Da;
     address internal constant MASTER_FEE_HANDLER = 0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f;
 
     address internal constant SWAP_HOOK = 0x0591a87D3a56797812C4DA164C1B005c545400Cc;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -45,7 +45,7 @@ library DeploymentsSepolia {
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
     address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xdf507841a9Ba153e244767CcFE062Ba0DF7bCf40;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x3fA555A47f4Fb420D65063702a81cC43A20Df3ef;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x1285E96Fee2Fd4B1C4bee0b27ada91A5AC437bD7;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -16,6 +16,8 @@ library DeploymentsSepolia {
     address internal constant BONDING_CURVE = 0x1A7f2E2e4bdB14Dd75b6ce60ce7a6Ff7E0a3F3A5;
     address internal constant GRADUATOR_UNIV2 = 0x973B8F3b1e52244E79ecb86591C8FdA6E2D0e691;
     address internal constant GRADUATOR_UNIV4 = 0x85fE2051413a4b80b904f05841d1142FeF7f789c;
+    /// @notice V4 graduator paired with the 50-bps `SWAP_HOOK_0P5` variant. Update after deploying.
+    address internal constant GRADUATOR_UNIV4_0P5 = address(0);
     address internal constant MASTER_FEE_HANDLER = 0xcA5A02C3ADcEb4f37c2Bf6c6261EaD11166fb26f;
 
     address internal constant SWAP_HOOK = 0x0591a87D3a56797812C4DA164C1B005c545400Cc;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -45,7 +45,7 @@ library DeploymentsSepolia {
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
     address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xdf507841a9Ba153e244767CcFE062Ba0DF7bCf40;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x3330a265A1bF168234cA144D36e0c70Dc239250c;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x3fA555A47f4Fb420D65063702a81cC43A20Df3ef;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -248,6 +248,11 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///      Takes structs (not flat args) so future fields can be added to `TokenSetup`/configs
     ///      without growing this function's stack frame. Callers derive `tokenOwner` per their
     ///      venue policy (V2: always `address(0)`; V4: `msg.sender` unless renounced).
+    ///
+    ///      `graduator` is passed in by the caller (instead of read from the `GRADUATOR` immutable)
+    ///      so V4 can pick between multiple graduators per call based on `UniV4Configs.lpFeeBps`
+    ///      (one graduator per hardcoded LP-fee hook variant). V2 has a single graduator and
+    ///      always passes `address(GRADUATOR)`.
     /// @dev `tokenSetup` is `memory` so the legacy positional overload — whose ABI takes flat
     ///      calldata args — can build a `TokenSetup` in memory and call this same umbrella. The
     ///      string/`FeeShare[]` propagation forces `_validateInputs`/`_validateNameSymbol`/
@@ -258,6 +263,7 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     function _createToken(
         TokenSetup memory tokenSetup,
         address tokenOwner,
+        address graduator,
         SupplyShare[] calldata buyOnDeployShares,
         TaxConfigInit calldata taxConfigs,
         AntiSniperConfigs calldata antiSniperConfigs
@@ -267,7 +273,7 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         _validateTaxConfig(taxConfigs);
 
         token = _dispatchAndInitialize(
-            tokenSetup.name, tokenSetup.symbol, tokenSetup.salt, tokenOwner, taxConfigs, antiSniperConfigs
+            tokenSetup.name, tokenSetup.symbol, tokenSetup.salt, tokenOwner, graduator, taxConfigs, antiSniperConfigs
         );
 
         LAUNCHPAD.launchToken(token, BONDING_CURVE);
@@ -291,21 +297,20 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string memory name,
         string memory symbol,
         bytes32 salt,
-        address tokenOwner
+        address tokenOwner,
+        address graduator
     ) internal returns (address token, ILivoToken.InitializeParams memory params) {
         token = Clones.cloneDeterministic(impl, salt);
         // forge-lint: disable-next-line(unsafe-typecast)
         require(uint16(uint160(token)) == 0x1110, InvalidTokenAddress());
 
-        emit TokenCreated(
-            token, name, symbol, tokenOwner, address(LAUNCHPAD), address(GRADUATOR), address(MASTER_FEE_HANDLER)
-        );
+        emit TokenCreated(token, name, symbol, tokenOwner, address(LAUNCHPAD), graduator, address(MASTER_FEE_HANDLER));
 
         params = ILivoToken.InitializeParams({
             name: name,
             symbol: symbol,
             tokenOwner: tokenOwner,
-            graduator: address(GRADUATOR),
+            graduator: graduator,
             launchpad: address(LAUNCHPAD),
             feeHandler: address(MASTER_FEE_HANDLER)
         });
@@ -363,14 +368,15 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string memory symbol,
         bytes32 salt,
         address tokenOwner,
+        address graduator,
         TaxConfigInit calldata taxCfg,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         address impl = _previewTokenImplementation(taxCfg, antiSniperCfg);
         if (_isTaxConfigured(taxCfg)) {
-            token = _initializeTaxToken(impl, name, symbol, salt, tokenOwner, taxCfg, antiSniperCfg);
+            token = _initializeTaxToken(impl, name, symbol, salt, tokenOwner, graduator, taxCfg, antiSniperCfg);
         } else {
-            token = _initializeNonTaxToken(impl, name, symbol, salt, tokenOwner, antiSniperCfg);
+            token = _initializeNonTaxToken(impl, name, symbol, salt, tokenOwner, graduator, antiSniperCfg);
         }
     }
 
@@ -384,11 +390,12 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string memory symbol,
         bytes32 salt,
         address tokenOwner,
+        address graduator,
         TaxConfigInit calldata taxCfg,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         ILivoToken.InitializeParams memory params;
-        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner);
+        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner, graduator);
 
         if (_isAntiSniperConfigured(antiSniperCfg)) {
             ILivoTaxableTokenSniperProtected(payable(token)).initialize(params, taxCfg, antiSniperCfg);
@@ -406,10 +413,11 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         string memory symbol,
         bytes32 salt,
         address tokenOwner,
+        address graduator,
         AntiSniperConfigs calldata antiSniperCfg
     ) internal returns (address token) {
         ILivoToken.InitializeParams memory params;
-        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner);
+        (token, params) = _cloneAndCreateToken(impl, name, symbol, salt, tokenOwner, graduator);
 
         if (_isAntiSniperConfigured(antiSniperCfg)) {
             LivoTokenSniperProtected(token).initialize(params, antiSniperCfg);

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -53,10 +53,11 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     /// @notice Token implementation cloned when both tax and anti-sniper are configured.
     address public immutable TOKEN_IMPL_TAX_ANTISNIPER;
 
-    /// @notice Max configurable tax (buy or sell). Per-venue value supplied by the derived factory
-    ///         via `override`: V2 uses 5% (the swap-back path needs more headroom to amortise
-    ///         per-sell router gas); V4 uses 4%.
-    function MAX_TAX_BPS() public pure virtual returns (uint256);
+    /// @notice Cap on the aggregate fee a swapper pays (LP fee + tax), in basis points. Fixed at 5%.
+    ///         Enforced per call by `_validateTotalFee`. The tax headroom is venue-dependent because
+    ///         the LP fee varies: V2 has no LP fee, so tax can reach the full 5%; V4 charges 50 or
+    ///         100 bps in LP fees, leaving 450 or 400 bps for tax.
+    uint256 public constant MAX_TOTAL_FEE_BPS = 500;
 
     /// @notice Max percentage of total supply that can be purchased on token creation (applies to the
     ///         aggregate, not per recipient), in basis points. Fixed at 10%. To change this value,
@@ -316,20 +317,30 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         });
     }
 
-    /// @dev Validates a tax config: enforces sentinel consistency (zero duration ⇒ zero bps),
-    ///      caps `buyTaxBps`/`sellTaxBps` at `MAX_TAX_BPS`, and caps `taxDurationSeconds` at
-    ///      `MAX_TAX_DURATION_SECONDS` (120 years — an overflow-prevention bound driven by
-    ///      `uint32` packing on `TaxConfigInit.taxDurationSeconds`). No fee-receiver or
-    ///      ownership constraints are imposed at any duration.
+    /// @dev Validates a tax config: enforces sentinel consistency (zero duration ⇒ zero bps) and
+    ///      caps `taxDurationSeconds` at `MAX_TAX_DURATION_SECONDS` (120 years — an overflow-prevention
+    ///      bound driven by `uint32` packing on `TaxConfigInit.taxDurationSeconds`). The tax-bps
+    ///      ceiling is venue-dependent and enforced separately by `_validateTotalFee`. No fee-receiver
+    ///      or ownership constraints are imposed at any duration.
     function _validateTaxConfig(TaxConfigInit calldata t) internal pure {
         if (_isTaxConfigured(t)) {
             require(t.buyTaxBps > 0 || t.sellTaxBps > 0, InvalidTaxConfig());
-            uint256 maxTaxBps = MAX_TAX_BPS();
-            require(t.buyTaxBps <= maxTaxBps && t.sellTaxBps <= maxTaxBps, InvalidTaxBps());
             require(t.taxDurationSeconds <= MAX_TAX_DURATION_SECONDS, InvalidTaxDuration());
         } else {
             require(t.buyTaxBps == 0 && t.sellTaxBps == 0, InvalidTaxConfig());
         }
+    }
+
+    /// @dev Caps the aggregate fee a swapper pays (LP fee + tax) at `MAX_TOTAL_FEE_BPS` (5%). Applied
+    ///      to buy and sell tax independently since a swap only ever pays one direction. `lpFeeBps`
+    ///      is the venue's LP fee — 0 for V2 (no LP fee, so tax can reach the full 5%), 50 or 100 for
+    ///      V4 (leaving 450/400 bps for tax). `taxCfg` bps are unbounded here, so the sum is widened
+    ///      to `uint256` to avoid a spurious overflow revert before this check fires.
+    function _validateTotalFee(uint256 lpFeeBps, TaxConfigInit calldata taxCfg) internal pure {
+        require(
+            lpFeeBps + taxCfg.buyTaxBps <= MAX_TOTAL_FEE_BPS && lpFeeBps + taxCfg.sellTaxBps <= MAX_TOTAL_FEE_BPS,
+            InvalidTaxBps()
+        );
     }
 
     function _isTaxConfigured(TaxConfigInit calldata t) internal pure returns (bool) {

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -13,8 +13,8 @@ import {LivoFactoryAbstract} from "src/factories/LivoFactoryAbstract.sol";
 ///         covers the new tax variants (`LivoTaxableTokenUniV2`, `LivoTaxableTokenUniV2SniperProtected`).
 ///
 ///         Ownership rule: all V2-family tokens are deployed with `tokenOwner = address(0)`.
-///         Tax cap: 5% (vs V4's 4%) — the V2 swap-back path needs more headroom to amortise per-sell
-///         router gas, so a slightly higher cap keeps the tax slice meaningful.
+///         Tax cap: the full 5% aggregate fee cap (`MAX_TOTAL_FEE_BPS`) — V2 has no LP fee, so the
+///         tax can use all of it (vs V4, where the LP fee eats 50–100 bps of the budget).
 contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
     constructor(
         address launchpad,
@@ -38,11 +38,6 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         )
     {}
 
-    /// @inheritdoc LivoFactoryAbstract
-    function MAX_TAX_BPS() public pure override returns (uint256) {
-        return 500;
-    }
-
     /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
 
     /// @notice Deploys a V2-family Livo token and registers it in the launchpad.
@@ -61,6 +56,7 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         // V2-family tokens are always deployed ownerless. Routes through the shared `_createToken`
         // umbrella so this overload and the struct-based overload below share the same internal flow.
         // `LpFeeBpsSet` is emitted only by the V4 factory — V2 has no LP-fee concept.
+        _validateTotalFee(0, taxCfg);
         TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
         token = _createToken(tokenSetup, address(0), address(GRADUATOR), supplyShares, taxCfg, antiSniperCfg);
     }
@@ -75,6 +71,7 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         AntiSniperConfigs calldata antiSniperConfigs
     ) external payable returns (address token) {
         // V2-family tokens are always deployed ownerless; V2 never emits `LpFeeBpsSet`.
+        _validateTotalFee(0, taxConfigs);
         token =
             _createToken(tokenSetup, address(0), address(GRADUATOR), buyOnDeployShares, taxConfigs, antiSniperConfigs);
     }
@@ -93,6 +90,7 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
     ) external view returns (address) {
         _validateAntiSniperConfig(antiSniperCfg);
         _validateTaxConfig(taxCfg);
+        _validateTotalFee(0, taxCfg);
         return _previewTokenImplementation(taxCfg, antiSniperCfg);
     }
 }

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -62,7 +62,7 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         // umbrella so this overload and the struct-based overload below share the same internal flow.
         // `LpFeeBpsSet` is emitted only by the V4 factory — V2 has no LP-fee concept.
         TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
-        token = _createToken(tokenSetup, address(0), supplyShares, taxCfg, antiSniperCfg);
+        token = _createToken(tokenSetup, address(0), address(GRADUATOR), supplyShares, taxCfg, antiSniperCfg);
     }
 
     /// @notice Struct-based overload. Equivalent to the positional `createToken` above; exists to
@@ -75,7 +75,8 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         AntiSniperConfigs calldata antiSniperConfigs
     ) external payable returns (address token) {
         // V2-family tokens are always deployed ownerless; V2 never emits `LpFeeBpsSet`.
-        token = _createToken(tokenSetup, address(0), buyOnDeployShares, taxConfigs, antiSniperConfigs);
+        token =
+            _createToken(tokenSetup, address(0), address(GRADUATOR), buyOnDeployShares, taxConfigs, antiSniperConfigs);
     }
 
     /// @notice Returns which token implementation `createToken(...)` would clone for the given inputs.

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -54,11 +54,6 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         GRADUATOR_0P5 = graduator0p5;
     }
 
-    /// @inheritdoc LivoFactoryAbstract
-    function MAX_TAX_BPS() public pure override returns (uint256) {
-        return 400;
-    }
-
     /////////////////////// EXTERNAL FUNCTIONS /////////////////////////
 
     // V4-only event-emission rule: any event whose presence is meant to signal "this is a V4 token"
@@ -85,6 +80,7 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         // Positional overload always uses the 100-bps graduator/hook pair — only the struct-based
         // overload below exposes the 50-bps variant. See the "V4-only event-emission rule" comment
         // above for why the emit lives here.
+        _validateTotalFee(100, taxCfg);
         TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
         address tokenOwner = renounceOwnership_ ? address(0) : msg.sender;
         token = _createToken(tokenSetup, tokenOwner, address(GRADUATOR), supplyShares, taxCfg, antiSniperCfg);
@@ -102,6 +98,7 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         AntiSniperConfigs calldata antiSniperConfigs
     ) external payable returns (address token) {
         _validateUniv4Configs(univ4Configs);
+        _validateTotalFee(univ4Configs.lpFeeBps, taxConfigs);
         address tokenOwner = univ4Configs.renounceOwnership ? address(0) : msg.sender;
         address graduator = _resolveGraduator(univ4Configs.lpFeeBps);
         token = _createToken(tokenSetup, tokenOwner, graduator, buyOnDeployShares, taxConfigs, antiSniperConfigs);

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+    // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
 import {AntiSniperConfigs} from "src/tokens/SniperProtection.sol";
@@ -13,14 +13,19 @@ import {LivoFactoryAbstract} from "src/factories/LivoFactoryAbstract.sol";
 ///         and `LivoFactoryTaxTokenSniperProtected`.
 contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
     /// @notice V4-specific config bundle for the struct-based `createToken` overload.
-    /// @dev `lpFeeBps` is reserved for future use — today the LP fee is a constant in
-    ///      `LivoSwapHook` (100 bps). The field is accepted for ABI forward-compatibility but is
-    ///      not wired through; `_validateUniv4Configs` enforces `lpFeeBps == 100` so misuse is loud
-    ///      until the field is honoured by the hook.
+    /// @dev `lpFeeBps` selects which graduator (and thus which `LivoSwapHook` instance) the token
+    ///      will use. Today only two values are accepted: `100` (routes to `GRADUATOR`) and `50`
+    ///      (routes to `GRADUATOR_0P5`). The fee itself is still hardcoded in each hook's bytecode;
+    ///      this field is the dispatch key, not a free-form bps value. `_validateUniv4Configs`
+    ///      enforces the allowlist so misconfiguration is loud.
     struct UniV4Configs {
         bool renounceOwnership;
         uint16 lpFeeBps;
     }
+
+    /// @notice Graduator paired with the 50-bps `LivoSwapHook` variant. The 100-bps graduator lives
+    ///         in the abstract base as `GRADUATOR`.
+    address public immutable GRADUATOR_0P5;
 
     error InvalidLpFeeBps();
 
@@ -32,6 +37,7 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         address tokenImplTaxAntiSniper,
         address bondingCurve,
         address graduator,
+        address graduator0p5,
         address masterFeeHandler
     )
         LivoFactoryAbstract(
@@ -44,7 +50,9 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
             graduator,
             masterFeeHandler
         )
-    {}
+    {
+        GRADUATOR_0P5 = graduator0p5;
+    }
 
     /// @inheritdoc LivoFactoryAbstract
     function MAX_TAX_BPS() public pure override returns (uint256) {
@@ -74,19 +82,18 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         TaxConfigInit calldata taxCfg,
         AntiSniperConfigs calldata antiSniperCfg
     ) external payable returns (address token) {
-        // Routes through the shared `_createToken` umbrella so this overload and the struct-based
-        // overload below share the same internal flow. `lpFeeBps = 100` matches the value hardcoded
-        // in `LivoSwapHook` today; the struct overload reads it from `UniV4Configs` instead.
-        // See the "V4-only event-emission rule" comment above for why the emit lives here.
+        // Positional overload always uses the 100-bps graduator/hook pair — only the struct-based
+        // overload below exposes the 50-bps variant. See the "V4-only event-emission rule" comment
+        // above for why the emit lives here.
         TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
         address tokenOwner = renounceOwnership_ ? address(0) : msg.sender;
-        token = _createToken(tokenSetup, tokenOwner, supplyShares, taxCfg, antiSniperCfg);
+        token = _createToken(tokenSetup, tokenOwner, address(GRADUATOR), supplyShares, taxCfg, antiSniperCfg);
         emit LpFeeBpsSet(token, 100);
     }
 
     /// @notice Struct-based overload. Equivalent to the positional `createToken` above; exists to
     ///         keep the ABI extensible without hitting stack-too-deep when new features add inputs.
-    ///         `univ4Configs.lpFeeBps` is reserved for future use (see `UniV4Configs`).
+    ///         `univ4Configs.lpFeeBps` selects which graduator/hook pair to use (100 or 50).
     function createToken(
         TokenSetup calldata tokenSetup,
         TaxConfigInit calldata taxConfigs,
@@ -96,17 +103,26 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
     ) external payable returns (address token) {
         _validateUniv4Configs(univ4Configs);
         address tokenOwner = univ4Configs.renounceOwnership ? address(0) : msg.sender;
-        token = _createToken(tokenSetup, tokenOwner, buyOnDeployShares, taxConfigs, antiSniperConfigs);
+        address graduator = _resolveGraduator(univ4Configs.lpFeeBps);
+        token = _createToken(tokenSetup, tokenOwner, graduator, buyOnDeployShares, taxConfigs, antiSniperConfigs);
         emit LpFeeBpsSet(token, univ4Configs.lpFeeBps);
     }
 
     ///////////////////////// INTERNAL FUNCTIONS /////////////////////////
 
-    /// @dev V4-specific config validation. Today only pins `lpFeeBps == 100` because the LP fee is
-    ///      still hardcoded in `LivoSwapHook`; reject anything else so misconfiguration is loud
-    ///      instead of silently ignored. Add further V4-only invariants here as the struct grows.
+    /// @dev V4-specific config validation. `lpFeeBps` is the dispatch key for graduator/hook
+    ///      selection — only the values matching a deployed hook variant are accepted, so a typo
+    ///      reverts instead of silently routing to the wrong graduator. Add further V4-only
+    ///      invariants here as the struct grows.
     function _validateUniv4Configs(UniV4Configs calldata configs) internal pure {
-        require(configs.lpFeeBps == 100, InvalidLpFeeBps());
+        require(configs.lpFeeBps == 100 || configs.lpFeeBps == 50, InvalidLpFeeBps());
+    }
+
+    /// @dev Maps `lpFeeBps` to the graduator that pairs with the matching `LivoSwapHook` variant.
+    ///      Callers MUST pre-validate `lpFeeBps` via `_validateUniv4Configs`; this function trusts
+    ///      its input and treats anything other than 100 as the 50-bps branch.
+    function _resolveGraduator(uint16 lpFeeBps) internal view returns (address) {
+        return lpFeeBps == 100 ? address(GRADUATOR) : GRADUATOR_0P5;
     }
 
     /// @notice Returns which token implementation `createToken(...)` would clone for the given inputs.

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -1,4 +1,4 @@
-    // SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
 import {AntiSniperConfigs} from "src/tokens/SniperProtection.sol";

--- a/test/factories/FactoryUpgrade.t.sol
+++ b/test/factories/FactoryUpgrade.t.sol
@@ -25,6 +25,7 @@ contract FactoryUpgradeTests is LaunchpadBaseTestsWithUniv4Graduator {
                 address(livoTaxTokenSniper),
                 address(bondingCurve),
                 newGraduator,
+                newGraduator,
                 address(feeHandler)
             )
         );

--- a/test/factories/LivoFactoryUniV4Unified.t.sol
+++ b/test/factories/LivoFactoryUniV4Unified.t.sol
@@ -230,6 +230,65 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
         );
     }
 
+    // ───────────── Aggregate fee cap: LP fee + tax never exceeds 5% ─────────────
+    //
+    // The fee a swapper pays is LP fee + tax. The positional overload always uses the 1% LP hook,
+    // so tax is capped at 4%. The struct overload exposes the 0.5% LP hook, where tax can go to 4.5%.
+
+    function test_createToken_positional_succeedsAtFourPercentTax() public {
+        // 1% LP + 4% tax (buy and sell) == 5% total, the boundary.
+        bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoTaxToken));
+        vm.prank(creator);
+        factoryV4Unified.createToken(
+            "T", "T", salt, _fs(creator), _noSs(), false, _taxCfg(400, 400, uint32(14 days)), _emptyAntiSniperCfg()
+        );
+    }
+
+    function test_createToken_positional_revertsWhenBuyTaxExceedsFourPercent() public {
+        // 1% LP + 4.01% buy tax == 5.01% total > 5%.
+        vm.prank(creator);
+        vm.expectRevert(ILivoFactory.InvalidTaxBps.selector);
+        factoryV4Unified.createToken(
+            "T", "T", "0x12", _fs(creator), _noSs(), false, _taxCfg(401, 0, uint32(14 days)), _emptyAntiSniperCfg()
+        );
+    }
+
+    function test_createToken_struct_halfPercentLp_succeedsAtFourPointFivePercentTax() public {
+        // 0.5% LP + 4.5% tax (buy and sell) == 5% total, the boundary.
+        bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoTaxToken));
+        ILivoFactory.TokenSetup memory setup =
+            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: salt, feeShares: _fs(creator)});
+        LivoFactoryUniV4Unified.UniV4Configs memory cfg =
+            LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 50});
+
+        vm.prank(creator);
+        factoryV4Unified.createToken(setup, _taxCfg(450, 450, uint32(14 days)), cfg, _noSs(), _emptyAntiSniperCfg());
+    }
+
+    function test_createToken_struct_halfPercentLp_revertsAboveFourPointFivePercentTax() public {
+        // 0.5% LP + 4.51% sell tax == 5.01% total > 5%.
+        ILivoFactory.TokenSetup memory setup =
+            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator)});
+        LivoFactoryUniV4Unified.UniV4Configs memory cfg =
+            LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 50});
+
+        vm.prank(creator);
+        vm.expectRevert(ILivoFactory.InvalidTaxBps.selector);
+        factoryV4Unified.createToken(setup, _taxCfg(0, 451, uint32(14 days)), cfg, _noSs(), _emptyAntiSniperCfg());
+    }
+
+    function test_createToken_struct_onePercentLp_revertsAboveFourPercentTax() public {
+        // 1% LP + 4.01% buy tax == 5.01% total > 5%, even though 4.01% is below the absolute cap.
+        ILivoFactory.TokenSetup memory setup =
+            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator)});
+        LivoFactoryUniV4Unified.UniV4Configs memory cfg =
+            LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
+
+        vm.prank(creator);
+        vm.expectRevert(ILivoFactory.InvalidTaxBps.selector);
+        factoryV4Unified.createToken(setup, _taxCfg(401, 0, uint32(14 days)), cfg, _noSs(), _emptyAntiSniperCfg());
+    }
+
     function test_createToken_revertsOnInvalidTaxDuration() public {
         vm.prank(creator);
         vm.expectRevert(ILivoFactory.InvalidTaxDuration.selector);

--- a/test/invariants/baseInvariants.t.sol
+++ b/test/invariants/baseInvariants.t.sol
@@ -116,6 +116,7 @@ contract LaunchpadInvariants is Test {
                 address(tokenImplementation),
                 address(bondingCurve),
                 address(graduatorV4),
+                address(graduatorV4),
                 address(feeHandler)
             )
         );

--- a/test/launchpad/base.t.sol
+++ b/test/launchpad/base.t.sol
@@ -261,6 +261,7 @@ contract LaunchpadBaseTests is Test {
                 address(livoTaxTokenSniper),
                 address(bondingCurve),
                 address(graduatorV4),
+                address(graduatorV4),
                 address(feeHandler)
             )
         );


### PR DESCRIPTION
## IMPORTANT

Waiting until uniswap whitelists the new hook with the hardcoded 0.5%. Once that happens, the plan is:
- deploy new graduator pointing to new 0.5% hook
- deploy new univ4 factory implementation, accepting 1/0.5% lp fees

Note: the frontend will still work even after the implementation upgrade, since the abis have already been changed and only the lp fee selection is missing (lp == 100 harcoded currently) 


## Summary
- Relax the V4 factory's struct-based `createToken` to accept `lpFeeBps` of `50` in addition to `100`. The value is the dispatch key for which `LivoSwapHook`/`LivoGraduatorUniswapV4` pair the token will use — anything else reverts with `InvalidLpFeeBps`.
- Add a second `GRADUATOR_0P5` immutable + constructor arg on `LivoFactoryUniV4Unified`; the per-call graduator now flows through `_createToken` → `_dispatchAndInitialize` → `_initializeTaxToken`/`_initializeNonTaxToken` → `_cloneAndCreateToken` so `TokenCreated` and `InitializeParams.graduator` carry the resolved address. V2 keeps a single graduator and passes `address(GRADUATOR)` through unchanged.
- Wire `GRADUATOR_UNIV4_0P5` (placeholder `address(0)`) into both per-chain manifests, the export script, and every factory deploy/upgrade script (8 construction sites). New `DeployUniV4Graduator0p5.s.sol` deploys a single `LivoGraduatorUniswapV4` pointed at the already-deployed `SWAP_HOOK_0P5`; existing 1% graduator is untouched.

## Test plan
- [x] `just fast-test` — 994 passed, 0 failed
- [ ] Dry-run `DeployUniV4Graduator0p5` on sepolia, paste address into manifest, dry-run `UpgradeUnifiedFactories`
- [ ] After upgrade, mint a token through the struct overload with `lpFeeBps = 50` on sepolia and confirm `TokenCreated.graduator` matches `GRADUATOR_UNIV4_0P5` and `LpFeeBpsSet` emits `50`
- [ ] Mint a token with `lpFeeBps = 100` on sepolia to confirm the 100-bps path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)