### PR TITLE
feat(sniper): raise whitelist cap to 20 wallets + refresh deployments

### DIFF
--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -17,14 +17,14 @@
 | LivoQuoter                                   | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
 | LivoToken (impl)                             | `0x0319E8C68cf293271f9C3Ad6C476DAe6Be40CdBD` |
 | LivoTaxableTokenUniV4 (impl)                 | `0xf68Ea9a3522647C58d7c77edE156cAA0930a7101` |
-| LivoTokenSniperProtected (impl)              | `0x4696F7e605E48f1E035154B4FCE19A62E8B5CbEE` |
-| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x1f4F57DdCda5f2697899eEBe763682279b7aE39a` |
+| LivoTokenSniperProtected (impl)              | `0x9BCf191ac1E73749402976eF7DA48C7c735485A7` |
+| LivoTaxableTokenUniV4SniperProtected (impl)  | `0x7B95cD8b8a91586d9e888039bdB9f527B51BdF15` |
 | LivoTaxableTokenUniV2 (impl)                 | `0xd2DF33c4e12b3F2eB838d2F936dA3ac708Dd33BF` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x0B1B9D5006bD2dE582068695F5fE8A50132f6975` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0xa8Ee5A48c40b20aF3cf0ff5F3Dca8341b0767220` |
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
-| LivoFactoryUniV2Unified (impl)               | `0xF470512f22bF50224e5Ea96673da1C1Fbb20018a` |
+| LivoFactoryUniV2Unified (impl)               | `0x69c61f4dE5523Fc41E2458221984479E1F59d4A4` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0xc28b19Fa83d025c8C76E44D8010d8e2A100029BD` |
+| LivoFactoryUniV4Unified (impl)               | `0x5a4491B4e762B39305698ae57F43b6d70b9E6377` |
 
 ## Accounts
 

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -17,14 +17,14 @@
 | LivoQuoter                                   | `0x288E9F2251Ea1BA930ef8D5DB654947Ece41F438` |
 | LivoToken (impl)                             | `0x9e11191aC22b1C25A64e8de86dd9Db098a343e01` |
 | LivoTaxableTokenUniV4 (impl)                 | `0xd9F88d337CF88126850d150651CFbCE5E5299f08` |
-| LivoTokenSniperProtected (impl)              | `0x35Ef85e3bcEb1dDE4DCe06fcBfe47312d899Db1C` |
-| LivoTaxableTokenUniV4SniperProtected (impl)  | `0xA582730d09028cff9582018ba74C7ad8A64d987E` |
+| LivoTokenSniperProtected (impl)              | `0x4Cf6178e0953b7B9E986265A8e1848551E4a7D5F` |
+| LivoTaxableTokenUniV4SniperProtected (impl)  | `0xE1B8aA73d0E964B9f7Fe49A7396795D5aa288ba0` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x462a3091a108D088DFdD029ba1BDFf593A55806E` |
-| LivoTaxableTokenUniV2SniperProtected (impl)  | `0x92a7da4ae6Fe3BFA57102e1d8Fe614d3a794Af0d` |
+| LivoTaxableTokenUniV2SniperProtected (impl)  | `0xFE05dA9BBd5e798B18c3a1D1ae824a4a46cC1674` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0xdf507841a9Ba153e244767CcFE062Ba0DF7bCf40` |
+| LivoFactoryUniV2Unified (impl)               | `0x11dD23Bd02eFAEC83CD4AdB2B23616A79196c107` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0x1285E96Fee2Fd4B1C4bee0b27ada91A5AC437bD7` |
+| LivoFactoryUniV4Unified (impl)               | `0xBae6fA24aF026D1309632A76308894c62B6E029E` |
 
 ## Accounts
 

--- a/docs/external/factory-createToken-integration.md
+++ b/docs/external/factory-createToken-integration.md
@@ -78,7 +78,7 @@ struct AntiSniperConfigs {
     uint16    maxBuyPerTxBps;        // 10..300 (0.1%..3% of TOTAL_SUPPLY)
     uint16    maxWalletBps;          // 10..300, must be >= maxBuyPerTxBps
     uint40    protectionWindowSeconds; // 0 disables; otherwise 60..86400
-    address[] whitelist;             // up to 5 addresses that bypass the caps
+    address[] whitelist;             // up to 20 addresses that bypass the caps
 }
 ```
 
@@ -173,7 +173,7 @@ Once `protectionWindowSeconds > 0`, the **token's** initializer enforces the sub
 | `maxBuyPerTxBps > maxWalletBps` | `MaxBuyPerTxBpsExceedsMaxWalletBps` |
 | `protectionWindowSeconds < 60` | `ProtectionWindowTooShort` |
 | `protectionWindowSeconds > 86_400` | `ProtectionWindowTooLong` |
-| `whitelist.length > 5` | `WhitelistTooLong` |
+| `whitelist.length > 20` | `WhitelistTooLong` |
 
 ### Tax config (`taxCfg`)
 

--- a/src/config/deployments.mainnet.sol
+++ b/src/config/deployments.mainnet.sol
@@ -28,12 +28,12 @@ library DeploymentsMainnet {
     address internal constant TAXABLE_TOKEN_IMPL = 0xf68Ea9a3522647C58d7c77edE156cAA0930a7101;
 
     /// @notice Sniper-protected token implementations
-    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0x4696F7e605E48f1E035154B4FCE19A62E8B5CbEE;
-    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x1f4F57DdCda5f2697899eEBe763682279b7aE39a;
+    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0x9BCf191ac1E73749402976eF7DA48C7c735485A7;
+    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0x7B95cD8b8a91586d9e888039bdB9f527B51BdF15;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
     address internal constant TAXABLE_TOKEN_V2_IMPL = 0xd2DF33c4e12b3F2eB838d2F936dA3ac708Dd33BF;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x0B1B9D5006bD2dE582068695F5fE8A50132f6975;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0xa8Ee5A48c40b20aF3cf0ff5F3Dca8341b0767220;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -43,8 +43,8 @@ library DeploymentsMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xF470512f22bF50224e5Ea96673da1C1Fbb20018a;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xc28b19Fa83d025c8C76E44D8010d8e2A100029BD;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x69c61f4dE5523Fc41E2458221984479E1F59d4A4;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x5a4491B4e762B39305698ae57F43b6d70b9E6377;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/config/deployments.sepolia.sol
+++ b/src/config/deployments.sepolia.sol
@@ -29,12 +29,12 @@ library DeploymentsSepolia {
     address internal constant TAXABLE_TOKEN_IMPL = 0xd9F88d337CF88126850d150651CFbCE5E5299f08;
 
     /// @notice Sniper-protected token implementations
-    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0x35Ef85e3bcEb1dDE4DCe06fcBfe47312d899Db1C;
-    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0xA582730d09028cff9582018ba74C7ad8A64d987E;
+    address internal constant TOKEN_SNIPER_PROTECTED_IMPL = 0x4Cf6178e0953b7B9E986265A8e1848551E4a7D5F;
+    address internal constant TAXABLE_TOKEN_SNIPER_PROTECTED_IMPL = 0xE1B8aA73d0E964B9f7Fe49A7396795D5aa288ba0;
 
     /// @notice V2 taxable token implementations (cloned by `LivoFactoryUniV2Unified` when tax is configured)
     address internal constant TAXABLE_TOKEN_V2_IMPL = 0x462a3091a108D088DFdD029ba1BDFf593A55806E;
-    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0x92a7da4ae6Fe3BFA57102e1d8Fe614d3a794Af0d;
+    address internal constant TAXABLE_TOKEN_V2_SNIPER_PROTECTED_IMPL = 0xFE05dA9BBd5e798B18c3a1D1ae824a4a46cC1674;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -44,8 +44,8 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xdf507841a9Ba153e244767CcFE062Ba0DF7bCf40;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x1285E96Fee2Fd4B1C4bee0b27ada91A5AC437bD7;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x11dD23Bd02eFAEC83CD4AdB2B23616A79196c107;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xBae6fA24aF026D1309632A76308894c62B6E029E;
 
     // --- Accounts ---
     address internal constant LIVO_DEV = 0xBa489180Ea6EEB25cA65f123a46F3115F388f181;

--- a/src/tokens/SniperProtection.sol
+++ b/src/tokens/SniperProtection.sol
@@ -33,7 +33,7 @@ abstract contract SniperProtection {
     uint40 public constant ANTI_SNIPER_MAX_WINDOW = 1 days;
 
     /// @notice Max whitelist entries (includes the deployer if the dev opts to add it).
-    uint256 public constant MAX_WHITELISTED = 5;
+    uint256 public constant MAX_WHITELISTED = 20;
 
     /// @dev Mirrors `LivoToken.TOTAL_SUPPLY`; renamed to avoid a multiple-inheritance collision.
     uint256 internal constant _ANTI_SNIPER_TOTAL_SUPPLY = 1_000_000_000e18;


### PR DESCRIPTION
## Summary

Raises the anti-sniper whitelist cap from **5 to 20 wallets** and refreshes the deployment manifests for the redeployed contracts.

## Changes

- **`SniperProtection.sol`**: `MAX_WHITELISTED` constant `5 → 20`.
- **`docs/external/factory-createToken-integration.md`**: updated whitelist limit references and the `WhitelistTooLong` error condition.
- **Deployment manifests** (`deployments.{mainnet,sepolia}.sol` + regenerated `.md`): updated sniper-protected token implementations (`LivoToken`, `LivoTaxableTokenUniV2`, `LivoTaxableTokenUniV4`) and unified factory implementations (`UniV2`, `UniV4`) for both chains.
