### PR TITLE
feat(factories): referral createToken overload + collapse tier-less overload

### DIFF
--- a/abis/LivoFactoryUniV2Unified.json
+++ b/abis/LivoFactoryUniV2Unified.json
@@ -713,6 +713,187 @@
             "internalType": "uint256"
           }
         ]
+      },
+      {
+        "name": "referral",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "createToken",
+    "inputs": [
+      {
+        "name": "tokenSetup",
+        "type": "tuple",
+        "internalType": "struct ILivoFactory.TokenSetupTiered",
+        "components": [
+          {
+            "name": "name",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "symbol",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "salt",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "feeShares",
+            "type": "tuple[]",
+            "internalType": "struct ILivoFactory.FeeShare[]",
+            "components": [
+              {
+                "name": "account",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "shares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "directFeesEnabled",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "liquidityTier",
+            "type": "uint8",
+            "internalType": "enum LiquidityTier"
+          }
+        ]
+      },
+      {
+        "name": "taxConfigs",
+        "type": "tuple",
+        "internalType": "struct TaxConfigs",
+        "components": [
+          {
+            "name": "buyTaxBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "sellTaxBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "taxDurationSeconds",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "startTaxFromLaunch",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "buyTaxDecayStartBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "sellTaxDecayStartBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "taxDecayDuration",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      },
+      {
+        "name": "buyOnDeployShares",
+        "type": "tuple[]",
+        "internalType": "struct ILivoFactory.SupplyShare[]",
+        "components": [
+          {
+            "name": "account",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "shares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "antiSniperConfigs",
+        "type": "tuple",
+        "internalType": "struct AntiSniperConfigs",
+        "components": [
+          {
+            "name": "maxBuyPerTxBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "maxWalletBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "protectionWindowSeconds",
+            "type": "uint40",
+            "internalType": "uint40"
+          },
+          {
+            "name": "whitelist",
+            "type": "address[]",
+            "internalType": "address[]"
+          }
+        ]
+      },
+      {
+        "name": "creatorVaults",
+        "type": "tuple[]",
+        "internalType": "struct ILivoFactory.CreatorVault[]",
+        "components": [
+          {
+            "name": "owner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "supplyBps",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "cliffSeconds",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "vestingSeconds",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
       }
     ],
     "outputs": [
@@ -833,177 +1014,6 @@
             "name": "whitelist",
             "type": "address[]",
             "internalType": "address[]"
-          }
-        ]
-      }
-    ],
-    "outputs": [
-      {
-        "name": "token",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "stateMutability": "payable"
-  },
-  {
-    "type": "function",
-    "name": "createToken",
-    "inputs": [
-      {
-        "name": "tokenSetup",
-        "type": "tuple",
-        "internalType": "struct ILivoFactory.TokenSetup",
-        "components": [
-          {
-            "name": "name",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "symbol",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "salt",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "feeShares",
-            "type": "tuple[]",
-            "internalType": "struct ILivoFactory.FeeShare[]",
-            "components": [
-              {
-                "name": "account",
-                "type": "address",
-                "internalType": "address"
-              },
-              {
-                "name": "shares",
-                "type": "uint256",
-                "internalType": "uint256"
-              },
-              {
-                "name": "directFeesEnabled",
-                "type": "bool",
-                "internalType": "bool"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "taxConfigs",
-        "type": "tuple",
-        "internalType": "struct TaxConfigs",
-        "components": [
-          {
-            "name": "buyTaxBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "sellTaxBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "taxDurationSeconds",
-            "type": "uint32",
-            "internalType": "uint32"
-          },
-          {
-            "name": "startTaxFromLaunch",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "buyTaxDecayStartBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "sellTaxDecayStartBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "taxDecayDuration",
-            "type": "uint32",
-            "internalType": "uint32"
-          }
-        ]
-      },
-      {
-        "name": "buyOnDeployShares",
-        "type": "tuple[]",
-        "internalType": "struct ILivoFactory.SupplyShare[]",
-        "components": [
-          {
-            "name": "account",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "shares",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      },
-      {
-        "name": "antiSniperConfigs",
-        "type": "tuple",
-        "internalType": "struct AntiSniperConfigs",
-        "components": [
-          {
-            "name": "maxBuyPerTxBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "maxWalletBps",
-            "type": "uint16",
-            "internalType": "uint16"
-          },
-          {
-            "name": "protectionWindowSeconds",
-            "type": "uint40",
-            "internalType": "uint40"
-          },
-          {
-            "name": "whitelist",
-            "type": "address[]",
-            "internalType": "address[]"
-          }
-        ]
-      },
-      {
-        "name": "creatorVaults",
-        "type": "tuple[]",
-        "internalType": "struct ILivoFactory.CreatorVault[]",
-        "components": [
-          {
-            "name": "owner",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "supplyBps",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "cliffSeconds",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "vestingSeconds",
-            "type": "uint256",
-            "internalType": "uint256"
           }
         ]
       }
@@ -1482,6 +1492,25 @@
         "name": "feeHandler",
         "type": "address",
         "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenReferral",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "referral",
+        "type": "address",
+        "indexed": true,
         "internalType": "address"
       }
     ],

--- a/abis/LivoFactoryUniV4Unified.json
+++ b/abis/LivoFactoryUniV4Unified.json
@@ -659,7 +659,7 @@
       {
         "name": "tokenSetup",
         "type": "tuple",
-        "internalType": "struct ILivoFactory.TokenSetup",
+        "internalType": "struct ILivoFactory.TokenSetupTiered",
         "components": [
           {
             "name": "name",
@@ -697,6 +697,11 @@
                 "internalType": "bool"
               }
             ]
+          },
+          {
+            "name": "liquidityTier",
+            "type": "uint8",
+            "internalType": "enum LiquidityTier"
           }
         ]
       },
@@ -829,6 +834,11 @@
             "internalType": "uint256"
           }
         ]
+      },
+      {
+        "name": "referral",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "outputs": [
@@ -1642,6 +1652,25 @@
         "name": "feeHandler",
         "type": "address",
         "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenReferral",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "referral",
+        "type": "address",
+        "indexed": true,
         "internalType": "address"
       }
     ],

--- a/deployments.mainnet.md
+++ b/deployments.mainnet.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x93AcF08eE9bABa0672bd1ae668dEbb5d9fdfE354` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x79ab23C9f95D8B7ae96EA789F20a81A945C7cca9` |
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
-| LivoFactoryUniV2Unified (impl)               | `0x788e16a74721A826c6DCD81B72146a084E3A53C7` |
+| LivoFactoryUniV2Unified (impl)               | `0x03AfF3484c04BeD2B2eA63b55475F03318eF7EA9` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0x1aD900af50601255AB08Cd0491F9DCFcfaC41fC4` |
+| LivoFactoryUniV4Unified (impl)               | `0x178A14654D080450e5Cf11b8f6114c6280Df7828` |
 | LivoCreatorVaultFactory (proxy)              | `0xA06f07bf255cB63c694339F172f9459f3BF015E7` |
 | LivoCreatorVaultFactory (impl)               | `0x4b387716EbA7498Eb757467A876FAA98733A329e` |
 | LivoCreatorVault (impl)                      | `0xcad4C889e0897BF3fdeE367F402F728342651603` |

--- a/deployments.sepolia.md
+++ b/deployments.sepolia.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x61054ec92636c2e4eE1ecE05F7F9bE7D240F24dA` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x76bA7d2d05b76CA78bF7504ede5c2E607Acfc328` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0xD6CB866D7f5630EACfE43A57d70058C4686a9f77` |
+| LivoFactoryUniV2Unified (impl)               | `0x174a043E00C527e3D1a8e0bc19fE1E15e4e859f6` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0xD1D09BBCeDEFfd8dc46F708F417908c57aEA64EE` |
+| LivoFactoryUniV4Unified (impl)               | `0x8ED7408Def91C96E7C76df3FA9B3a15918E5b1bd` |
 | LivoCreatorVaultFactory (proxy)              | `0x804ad45394FCF755350d924f712EC463E5E3147D` |
 | LivoCreatorVaultFactory (impl)               | `0xcbeBF86091de0E2c5d18D6c4E3d44e44855C2C47` |
 | LivoCreatorVault (impl)                      | `0xe5aF8d840963060302cf5021630d6dBF41a9e07b` |

--- a/docs/create-token-recommended-overload.md
+++ b/docs/create-token-recommended-overload.md
@@ -1,0 +1,228 @@
+# Deploying a token: the recommended `createToken` overload (V2 & V4)
+
+This documents the **struct-based `createToken` overload with `referral`** — the current
+recommended entry point on both unified factories:
+
+- `LivoFactoryUniV2Unified` (graduates to Uniswap V2)
+- `LivoFactoryUniV4Unified` (graduates to Uniswap V4)
+
+> **Which overload is "the third one"?** ABI order ≠ source order. In
+> `src/factories/LivoFactoryUniV2Unified.sol` this `referral` overload is literally the 3rd
+> `createToken`. In `abis/LivoFactoryUniV4Unified.json` the same overload is listed **first**;
+> the ABI's 3rd entry is this signature **minus** the trailing `referral`. Documenting the
+> `referral` variant covers both — `referral` is just an optional trailing arg (pass
+> `address(0)` for "none", which behaves exactly like the non-referral overload).
+
+## Signatures
+
+```solidity
+// V2 — LivoFactoryUniV2Unified
+function createToken(
+    TokenSetupTiered   tokenSetup,
+    TaxConfigs         taxConfigs,
+    SupplyShare[]      buyOnDeployShares,
+    AntiSniperConfigs  antiSniperConfigs,
+    CreatorVault[]     creatorVaults,
+    address            referral
+) external payable returns (address token);
+
+// V4 — LivoFactoryUniV4Unified  (identical, plus `univ4Configs` in position 3)
+function createToken(
+    TokenSetupTiered   tokenSetup,
+    TaxConfigs         taxConfigs,
+    UniV4Configs       univ4Configs,   // V4 only
+    SupplyShare[]      buyOnDeployShares,
+    AntiSniperConfigs  antiSniperConfigs,
+    CreatorVault[]     creatorVaults,
+    address            referral
+) external payable returns (address token);
+```
+
+`TOTAL_SUPPLY` is always `1_000_000_000e18`. All bps values are basis points (`10_000` = 100%).
+
+---
+
+## Arguments
+
+### `tokenSetup` — `TokenSetupTiered`
+
+| field | type | meaning / expected value |
+|---|---|---|
+| `name` | `string` | Token name. Non-empty. |
+| `symbol` | `string` | Token symbol. Non-empty, **≤ 96 bytes**. |
+| `salt` | `bytes32` | Mined so the token address ends in `0x1110` — see [Salt mining](#salt-mining). |
+| `feeShares` | `FeeShare[]` | Fee recipients (see below). |
+| `liquidityTier` | `uint8` enum | `LiquidityTier`: `0 = THIN`, `1 = DEFAULT`, `2 = THICK`. **Set it explicitly** — a zero-initialised field resolves to `THIN`, not `DEFAULT`. Controls post-graduation pool depth / graduation mcap (THIN 1.75 ETH / DEFAULT 3.5 ETH / THICK 7.0 ETH). |
+
+`FeeShare`:
+
+| field | type | expected value |
+|---|---|---|
+| `account` | `address` | Non-zero, unique across the array. |
+| `shares` | `uint256` | bps, `> 0`; the array must sum to exactly `10_000`. |
+| `directFeesEnabled` | `bool` | At most **one** entry may be `true`. |
+
+### `taxConfigs` — `TaxConfigs`
+
+Static tax and the optional linear launch-tax decay are configured **independently**: set
+either, both, or neither. A "decay-only" token (static fields zero, decay fields set) is valid.
+
+| field | type | meaning / expected value |
+|---|---|---|
+| `buyTaxBps` | `uint16` | Long-term buy tax. `0` disables static tax. Capped by the total-fee rule below. |
+| `sellTaxBps` | `uint16` | Long-term sell tax. `0` disables static tax. Capped by the total-fee rule below. |
+| `taxDurationSeconds` | `uint32` | Static-tax window length. `0` disables (then `buyTaxBps`/`sellTaxBps` must be `0`). Max `120 * 365 days`. |
+| `startTaxFromLaunch` | `bool` | Window anchor for **both** static and decay. `true`: `[launch, launch+duration]` (taxed pre-graduation too). `false`: `[graduation, graduation+duration]` (no tax before graduation). |
+| `buyTaxDecayStartBps` | `uint16` | Buy decay rate at the anchor, decaying linearly to 0. `0` = no buy decay. If set, must be `> buyTaxBps`. |
+| `sellTaxDecayStartBps` | `uint16` | Sell decay rate at the anchor. `0` = no sell decay. If set, must be `> sellTaxBps`. |
+| `taxDecayDuration` | `uint32` | Decay window length. `0` disables decay (then both decay-start fields must be `0`). Max `20 minutes`. `buy+sell` decay starts combined ≤ `2_000` bps (20%). |
+
+Effective rate a trade pays per direction is `max(decay, static)`.
+
+**Total-fee cap** (static bps only): `lpFeeBps + buyTaxBps ≤ 500` and `lpFeeBps + sellTaxBps ≤ 500`.
+- V2: post-graduation LP fee is `0`, so **each direction's static tax ≤ 500 bps (5%)**.
+- V4: `lpFeeBps` is `univ4Configs.lpFeeBps`, so **static tax ≤ `500 − lpFeeBps`** → **400 bps** with the 100-bps hook, **450 bps** with the 50-bps hook.
+
+### `univ4Configs` — `UniV4Configs` *(V4 only)*
+
+| field | type | expected value |
+|---|---|---|
+| `renounceOwnership` | `bool` | `true` → token deployed ownerless (`tokenOwner = address(0)`). `false` → `tokenOwner = msg.sender`. |
+| `lpFeeBps` | `uint16` | Post-graduation hook fee selector. **Must be `100` or `50`** — anything else reverts. Picks the graduator/hook pair (1% or 0.5% pool fee). |
+
+> V2 has no equivalent: V2 tokens are **always** ownerless and carry **no** post-graduation LP fee.
+
+### `buyOnDeployShares` — `SupplyShare[]`
+
+Optional buy-on-deploy: if `msg.value > 0`, the factory buys from the curve and splits the tokens
+across these recipients.
+
+| field | type | expected value |
+|---|---|---|
+| `account` | `address` | Non-zero, unique across the array. |
+| `shares` | `uint256` | bps, `> 0`; the array must sum to exactly `10_000`. |
+
+Rules:
+- `msg.value == 0` ⇔ `buyOnDeployShares.length == 0` (pass one without the other → revert).
+- Aggregate tokens bought must be `≤ maxBuyOnDeployBps` = **1_000 bps (10%)** of supply. This is on the
+  aggregate — splitting across recipients does not bypass it.
+- Use `quoteBuyOnDeploy(liquidityTier, tokenAmount, totalLockedInVaultsBps, taxCfg[, univ4Configs])`
+  to compute the `msg.value` for a target token amount. It does **not** enforce the 10% cap — that's on you.
+
+### `antiSniperConfigs` — `AntiSniperConfigs`
+
+Opt-in via a non-zero `protectionWindowSeconds`. To **disable**, pass all zeros / empty array.
+
+| field | type | expected value (when enabled) |
+|---|---|---|
+| `maxBuyPerTxBps` | `uint16` | `10..300` (0.1%..3% of supply). |
+| `maxWalletBps` | `uint16` | `10..300`, and `≥ maxBuyPerTxBps`. |
+| `protectionWindowSeconds` | `uint40` | `0` disables. Otherwise `60 .. 86_400` (1 min .. 24 h). |
+| `whitelist` | `address[]` | Addresses that bypass caps during the window. **≤ 20** entries. |
+
+Sentinel: if `protectionWindowSeconds == 0`, then `maxBuyPerTxBps`, `maxWalletBps` and
+`whitelist.length` must all be `0`.
+
+### `creatorVaults` — `CreatorVault[]`
+
+Optional vesting vaults that lock part of the supply at deploy. Empty array = none.
+
+| field | type | expected value |
+|---|---|---|
+| `owner` | `address` | Non-zero. |
+| `supplyBps` | `uint256` | Non-zero **multiple of `500` (5%)**. Sum across all vaults ≤ `3_000` (30%). |
+| `cliffSeconds` | `uint256` | Unconstrained. |
+| `vestingSeconds` | `uint256` | Unconstrained. |
+
+At most **5** vaults. Locked supply selects an allocation-specific bonding curve for the chosen tier
+(so the same `liquidityTier` graduation invariants hold with a relaxed starting mcap).
+
+### `referral` — `address`
+
+Off-chain signal for relayers. If non-zero, emits `TokenReferral(token, referral)`. **No** on-chain
+storage or payout is wired to it (yet). Pass `address(0)` for none.
+
+---
+
+## Revert conditions
+
+All errors are 4-byte custom errors.
+
+| revert | when |
+|---|---|
+| `InvalidNameOrSymbol` | empty `name`; empty `symbol`; or `symbol` > 96 bytes. |
+| `InvalidTokenAddress` | cloned address doesn't end in `0x1110` (salt not mined against the dispatched impl / wrong deployer). |
+| `InvalidFeeReceiver` | `feeShares` empty, contains `address(0)`, or has duplicate accounts. |
+| `InvalidShares` | any `shares == 0`, or `feeShares` / `buyOnDeployShares` sum ≠ `10_000`. |
+| `MultipleDirectFeeReceivers` | more than one `feeShares` entry with `directFeesEnabled == true`. |
+| `InvalidSupplyShares` | `msg.value` and `buyOnDeployShares.length` disagree (one zero, one not); or zero/duplicate accounts. |
+| `InvalidBuyOnDeploy` | aggregate buy-on-deploy > 10% of supply. |
+| `InvalidTaxConfig` | tax sentinel mismatch: `taxDurationSeconds == 0` with non-zero bps (or vice-versa); or `taxDecayDuration == 0` with non-zero decay-start bps (or vice-versa). |
+| `InvalidTaxBps` | `lpFeeBps + buyTaxBps` or `lpFeeBps + sellTaxBps` > `500`; combined decay start > `2_000`; or a decay start ≤ its direction's static rate. |
+| `InvalidTaxDuration` | `taxDurationSeconds` > 120 years; `taxDecayDuration` > 20 min; or (both set) `taxDurationSeconds < taxDecayDuration`. |
+| `InvalidAntiSniperConfig` | `protectionWindowSeconds == 0` but another anti-sniper field is non-zero/non-empty. |
+| `MaxBuyPerTxBpsTooLow` / `…TooHigh` | (window enabled) `maxBuyPerTxBps` outside `10..300`. |
+| `MaxWalletBpsTooLow` / `…TooHigh` | (window enabled) `maxWalletBps` outside `10..300`. |
+| `MaxBuyPerTxBpsExceedsMaxWalletBps` | (window enabled) `maxBuyPerTxBps > maxWalletBps`. |
+| `ProtectionWindowTooShort` / `…TooLong` | (window enabled) `protectionWindowSeconds` outside `60..86_400`. |
+| `WhitelistTooLong` | `whitelist.length > 20`. |
+| `InvalidCreatorVault` | a vault `owner == address(0)`, or `supplyBps` is zero / not a multiple of 500. |
+| `CreatorVaultAllocationTooHigh` | sum of `supplyBps` > `3_000` (30%). |
+| `TooManyCreatorVaults` | more than 5 vaults. |
+| `InvalidLpFeeBps` | *(V4)* `univ4Configs.lpFeeBps` not `100` or `50`. |
+
+> Note: unlike the older frontend skill, this version has **no charity mode** — long tax durations
+> impose no fee-receiver or ownership constraints (only the 120-year overflow cap applies).
+
+---
+
+## Salt mining
+
+The token is a `Clones.cloneDeterministic` proxy; its address is a function of
+`(factory, impl, msg.sender, salt)`. The address **must end in `0x1110`** (else `InvalidTokenAddress`).
+
+Two things to get right:
+
+1. **Impl** — dispatch clones one of two impls: `TOKEN_IMPL_TAX` if the token is taxable
+   (`taxDurationSeconds != 0` **or** `taxDecayDuration != 0`), else `TOKEN_IMPL_BASE`. Anti-sniper
+   does **not** change the impl. Get the exact impl from
+   `previewTokenImplementation(feeShares, buyOnDeployShares, taxConfigs, antiSniperConfigs)` (view;
+   it runs the same tax/anti-sniper validation and returns the impl to mine against).
+2. **Deployer namespacing** — the effective CREATE2 salt is `keccak256(abi.encodePacked(msg.sender, salt))`.
+   Mine with the exact account that will send `createToken`. A salt mined for one sender yields a
+   different address for another (this is the front-run defense — a salt lifted from a pending tx is
+   useless to anyone else).
+
+Reference (viem):
+
+```javascript
+import { getCreate2Address, keccak256, concat, encodePacked, toHex, pad } from "viem";
+
+const PROXY_PREFIX = "0x3d602d80600a3d3981f3363d3d373d3d3d363d73";
+const PROXY_SUFFIX = "0x5af43d82803e903d91602b57fd5bf3";
+
+// impl = previewTokenImplementation(...); deployer = the createToken sender
+function findValidSalt(factory, impl, deployer) {
+  const initcodeHash = keccak256(concat([PROXY_PREFIX, impl, PROXY_SUFFIX]));
+  for (let i = 0n; ; i++) {
+    const salt = pad(toHex(i), { size: 32 });
+    const effectiveSalt = keccak256(encodePacked(["address", "bytes32"], [deployer, salt]));
+    const addr = getCreate2Address({ from: factory, salt: effectiveSalt, bytecodeHash: initcodeHash });
+    if (addr.toLowerCase().endsWith("1110")) return { salt, tokenAddress: addr };
+  }
+}
+```
+
+~65k iterations on average (sub-100ms). Recompute the initcode hash whenever the dispatch path
+(tax vs base) changes. If dispatch-relevant inputs differ between preview and submit, the mined
+address won't match and the call reverts with `InvalidTokenAddress`.
+
+---
+
+## Minimal call flow
+
+1. Build `(tokenSetup, taxConfigs[, univ4Configs], buyOnDeployShares, antiSniperConfigs, creatorVaults, referral)`.
+2. `impl = previewTokenImplementation(feeShares, buyOnDeployShares, taxConfigs, antiSniperConfigs)`.
+3. Mine `salt` against `(factory, impl, deployer)` → address ending in `0x1110`.
+4. *(optional)* `value = quoteBuyOnDeploy(liquidityTier, tokenAmount, totalLockedInVaultsBps, taxCfg[, univ4Configs])`.
+5. `createToken(...)` with `value` (`0` if not buying on deploy).

--- a/docs/events-per-entry-point.md
+++ b/docs/events-per-entry-point.md
@@ -59,8 +59,8 @@ External ERC20 / Uniswap / WETH / Permit2 events still occur in traces, but this
 
 Each unified factory exposes three `createToken` overloads with different selectors:
 - **Legacy positional** (deprecated): `(name, symbol, salt, feeReceivers, supplyShares, taxCfg, antiSniperCfg)` on V2 and the same plus `renounceOwnership_` on V4. Never creates creator vaults. Takes the legacy `TaxConfigInit` (static tax only) and always uses `LiquidityTier.DEFAULT`.
-- **Struct-based, tier-less** (tmp — current frontend ABI): `(TokenSetup, TaxConfigs, [UniV4Configs,] SupplyShare[], AntiSniperConfigs, CreatorVault[])` — struct-grouped inputs (to keep the ABI extensible without hitting stack-too-deep) plus a trailing `CreatorVault[]` (empty for none) that locks supply in vesting vaults. Takes the full `TaxConfigs` (static tax + the three launch-tax-decay fields). Always uses `LiquidityTier.DEFAULT`. The `TokenSetup` struct is kept tier-less so existing frontends keep their ABI; it is removed once the frontend adopts liquidity tiers.
-- **Struct-based, tiered** (current): the same shape but with `TokenSetupTiered` in place of `TokenSetup` — the superset identity struct that adds the `liquidityTier` field selecting the post-graduation pool depth. Also takes the full `TaxConfigs`.
+- **Struct-based, tiered** (backwards-compat): `(TokenSetupTiered, TaxConfigs, [UniV4Configs,] SupplyShare[], AntiSniperConfigs, CreatorVault[])` — struct-grouped inputs (to keep the ABI extensible without hitting stack-too-deep) plus a trailing `CreatorVault[]` (empty for none) that locks supply in vesting vaults. `TokenSetupTiered` carries the `liquidityTier` field selecting the post-graduation pool depth. Takes the full `TaxConfigs` (static tax + the three launch-tax-decay fields).
+- **Struct-based, tiered + referral** (current/recommended): the same shape plus a trailing `address referral` for relayers that forward the creation and are entitled to a cut of the fees. When `referral != address(0)` it additionally emits `LivoFactory.TokenReferral` (see §1.1 step 7). No token storage or on-chain payout is wired to the referral yet — it is purely an off-chain signal for now.
 
 The legacy positional overload internally lifts its `TaxConfigInit` into a `TaxConfigs` (decay fields zeroed) before dispatch, so all three share the same internal flow and emit the events listed below in the same order; only the two struct-based overloads can emit the creator-vault events in §1 step 4b.
 
@@ -82,7 +82,8 @@ For both unified factories, the common Livo event order is:
 5. Initial fee config is registered through the token into `LivoMasterFeeHandler`:
    - Zero or more **`LivoMasterFeeHandler.DirectReceiverRegistered`** (`token, receiver`) — one per initial direct receiver.
    - **`LivoMasterFeeHandler.SharesUpdated`** (`token, recipients, sharesBps`).
-6. V4 only: **`LivoFactory.LpFeeBpsSet`** (`token, lpFeeBps`) — emitted by `LivoFactoryUniV4Unified` for every created token, unconditionally (presence of the event is itself the V4-origin signal). `LivoFactoryUniV2Unified` never emits it. With `msg.value > 0`, this fires *after* the deployer-buy events listed in 1.2 — i.e., it is always the last factory event in the deploy tx.
+6. V4 only: **`LivoFactory.LpFeeBpsSet`** (`token, lpFeeBps`) — emitted by `LivoFactoryUniV4Unified` for every created token, unconditionally (presence of the event is itself the V4-origin signal). `LivoFactoryUniV2Unified` never emits it. With `msg.value > 0`, this fires *after* the deployer-buy events listed in 1.2.
+7. Referral overload only, and only when `referral != address(0)`: **`LivoFactory.TokenReferral`** (`token, referral`, both indexed) — records the relayer/referrer that forwarded the creation. Emitted last of all factory events (after `LpFeeBpsSet` on V4). Both factories emit it; the common no-referral deploy emits nothing here.
 
 Notes:
 

--- a/src/config/manifest.mainnet.sol
+++ b/src/config/manifest.mainnet.sol
@@ -38,8 +38,8 @@ library DeploymentsMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x788e16a74721A826c6DCD81B72146a084E3A53C7;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x1aD900af50601255AB08Cd0491F9DCFcfaC41fC4;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x03AfF3484c04BeD2B2eA63b55475F03318eF7EA9;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x178A14654D080450e5Cf11b8f6114c6280Df7828;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.sepolia.sol
+++ b/src/config/manifest.sepolia.sol
@@ -39,8 +39,8 @@ library DeploymentsSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xD6CB866D7f5630EACfE43A57d70058C4686a9f77;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xD1D09BBCeDEFfd8dc46F708F417908c57aEA64EE;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x174a043E00C527e3D1a8e0bc19fE1E15e4e859f6;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x8ED7408Def91C96E7C76df3FA9B3a15918E5b1bd;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -341,9 +341,9 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     }
 
     /// @dev Single shared `createToken` body called by both `createToken` overloads on each unified
-    ///      factory (legacy positional + new struct-based). Centralises validation → dispatch →
+    ///      factory (legacy positional + tiered struct-based). Centralises validation → dispatch →
     ///      launch → finalize so both signatures emit the exact same events in the same order.
-    ///      Takes structs (not flat args) so future fields can be added to `TokenSetup`/configs
+    ///      Takes structs (not flat args) so future fields can be added to `TokenSetupTiered`/configs
     ///      without growing this function's stack frame. Callers derive `tokenOwner` per their
     ///      venue policy (V2: always `address(0)`; V4: `msg.sender` unless renounced).
     ///
@@ -352,15 +352,14 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///      (one graduator per hardcoded LP-fee hook variant). V2 has a single graduator and
     ///      always passes `address(GRADUATOR)`.
     /// @dev `tokenSetup` is `memory` so the legacy positional overload — whose ABI takes flat
-    ///      calldata args — can build a `TokenSetup` in memory and call this same umbrella. The
+    ///      calldata args — can build a `TokenSetupTiered` in memory and call this same umbrella. The
     ///      string/`FeeShare[]` propagation forces `_validateInputs`/`_validateNameSymbol`/
     ///      `_validateFeeShares`/`_dispatchAndInitialize`/`_cloneAndCreateToken`/`_finalizeCreation`
     ///      to accept `memory` for those fields too. Once the legacy overload is removed, switch
     ///      `tokenSetup` (and the cascaded fields) back to `calldata` to skip the one-time copy
     ///      (~100–250 gas/deploy).
     function _createToken(
-        TokenSetup memory tokenSetup,
-        LiquidityTier liquidityTier,
+        TokenSetupTiered memory tokenSetup,
         address tokenOwner,
         address graduator,
         SupplyShare[] calldata buyOnDeployShares,
@@ -376,7 +375,7 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
         // is minted to this factory by the token initializer; everything else (`TOTAL_SUPPLY -
         // vaultAllocation`) is minted to the launchpad and sold on the resolved curve.
         (uint256 totalLockedInVaultsBps, uint256 vaultAllocation) = _validateCreatorVaults(creatorVaults);
-        ILivoBondingCurve bondingCurve = _resolveBondingCurve(liquidityTier, totalLockedInVaultsBps);
+        ILivoBondingCurve bondingCurve = _resolveBondingCurve(tokenSetup.liquidityTier, totalLockedInVaultsBps);
 
         token = _dispatchAndInitialize(
             tokenSetup.name,

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -83,44 +83,13 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         // params) before introducing the `taxConfigs` memory local, to keep the stack shallow enough
         // to compile without `via_ir`.
         // Legacy overload always uses the DEFAULT liquidity tier.
-        TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
+        TokenSetupTiered memory tokenSetup = TokenSetupTiered({
+            name: name, symbol: symbol, salt: salt, feeShares: feeReceivers, liquidityTier: LiquidityTier.DEFAULT
+        });
         TaxConfigs memory taxConfigs = _toTaxConfigs(taxCfg);
         _validateTotalFee(V2_POST_GRADUATION_LP_FEE_BPS, taxConfigs);
         token = _createToken(
-            tokenSetup,
-            LiquidityTier.DEFAULT,
-            address(0),
-            address(GRADUATOR),
-            supplyShares,
-            taxConfigs,
-            antiSniperCfg,
-            new CreatorVault[](0)
-        );
-    }
-
-    /// @notice TMP struct-based overload: full `TaxConfigs` (static tax + optional launch-tax decay) and a
-    ///         `creatorVaults` array (pass empty for none). Always uses `LiquidityTier.DEFAULT`.
-    /// @dev TEMPORARY: the tier-less overload existing frontends call while the liquidity-tier UI is not
-    ///      ready. Removed once the frontend adopts tiers; use the `TokenSetupTiered` overload below to
-    ///      select a tier.
-    function createToken(
-        TokenSetup calldata tokenSetup,
-        TaxConfigs calldata taxConfigs,
-        SupplyShare[] calldata buyOnDeployShares,
-        AntiSniperConfigs calldata antiSniperConfigs,
-        CreatorVault[] calldata creatorVaults
-    ) external payable returns (address token) {
-        // V2-family tokens are always deployed ownerless; V2 never emits `LpFeeBpsSet`.
-        _validateTotalFee(V2_POST_GRADUATION_LP_FEE_BPS, taxConfigs);
-        token = _createToken(
-            tokenSetup,
-            LiquidityTier.DEFAULT,
-            address(0),
-            address(GRADUATOR),
-            buyOnDeployShares,
-            taxConfigs,
-            antiSniperConfigs,
-            creatorVaults
+            tokenSetup, address(0), address(GRADUATOR), supplyShares, taxConfigs, antiSniperCfg, new CreatorVault[](0)
         );
     }
 
@@ -136,18 +105,8 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
     ) external payable returns (address token) {
         // V2-family tokens are always deployed ownerless; V2 never emits `LpFeeBpsSet`.
         _validateTotalFee(V2_POST_GRADUATION_LP_FEE_BPS, taxConfigs);
-        TokenSetup memory base = TokenSetup({
-            name: tokenSetup.name, symbol: tokenSetup.symbol, salt: tokenSetup.salt, feeShares: tokenSetup.feeShares
-        });
         token = _createToken(
-            base,
-            tokenSetup.liquidityTier,
-            address(0),
-            address(GRADUATOR),
-            buyOnDeployShares,
-            taxConfigs,
-            antiSniperConfigs,
-            creatorVaults
+            tokenSetup, address(0), address(GRADUATOR), buyOnDeployShares, taxConfigs, antiSniperConfigs, creatorVaults
         );
     }
 

--- a/src/factories/LivoFactoryUniV2Unified.sol
+++ b/src/factories/LivoFactoryUniV2Unified.sol
@@ -95,7 +95,8 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
 
     /// @notice Struct-based overload taking the full `TaxConfigs` (static tax + optional linear launch-tax
     ///         decay), a `creatorVaults` array (pass empty for none) and a `TokenSetupTiered` selecting the
-    ///         liquidity tier. This is the current recommended overload.
+    ///         liquidity tier. Kept for backwards compatibility; new integrations should use the `referral`
+    ///         overload below (the current recommended overload).
     function createToken(
         TokenSetupTiered calldata tokenSetup,
         TaxConfigs calldata taxConfigs,
@@ -108,6 +109,26 @@ contract LivoFactoryUniV2Unified is LivoFactoryAbstract {
         token = _createToken(
             tokenSetup, address(0), address(GRADUATOR), buyOnDeployShares, taxConfigs, antiSniperConfigs, creatorVaults
         );
+    }
+
+    /// @notice Recommended overload: same as the `TokenSetupTiered` overload plus a `referral` address for
+    ///         relayers that forward the creation and are entitled to a cut of the fees. When `referral` is
+    ///         non-zero a `TokenReferral(token, referral)` event is emitted; no token storage or on-chain
+    ///         payout is wired to it yet — it is purely an off-chain signal for now.
+    function createToken(
+        TokenSetupTiered calldata tokenSetup,
+        TaxConfigs calldata taxConfigs,
+        SupplyShare[] calldata buyOnDeployShares,
+        AntiSniperConfigs calldata antiSniperConfigs,
+        CreatorVault[] calldata creatorVaults,
+        address referral
+    ) external payable returns (address token) {
+        // V2-family tokens are always deployed ownerless; V2 never emits `LpFeeBpsSet`.
+        _validateTotalFee(V2_POST_GRADUATION_LP_FEE_BPS, taxConfigs);
+        token = _createToken(
+            tokenSetup, address(0), address(GRADUATOR), buyOnDeployShares, taxConfigs, antiSniperConfigs, creatorVaults
+        );
+        if (referral != address(0)) emit TokenReferral(token, referral);
     }
 
     /// @notice Returns which token implementation `createToken(...)` would clone for the given inputs.

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -127,12 +127,13 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         // params) before introducing the `taxConfigs` memory local, to keep the stack shallow enough
         // to compile without `via_ir`.
         // Legacy overload always uses the DEFAULT liquidity tier + the 100-bps graduator.
-        TokenSetup memory tokenSetup = TokenSetup({name: name, symbol: symbol, salt: salt, feeShares: feeReceivers});
+        TokenSetupTiered memory tokenSetup = TokenSetupTiered({
+            name: name, symbol: symbol, salt: salt, feeShares: feeReceivers, liquidityTier: LiquidityTier.DEFAULT
+        });
         TaxConfigs memory taxConfigs = _toTaxConfigs(taxCfg);
         _validateTotalFee(100, taxConfigs);
         token = _createToken(
             tokenSetup,
-            LiquidityTier.DEFAULT,
             renounceOwnership_ ? address(0) : msg.sender,
             address(GRADUATOR),
             supplyShares,
@@ -141,37 +142,6 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
             new CreatorVault[](0)
         );
         emit LpFeeBpsSet(token, 100);
-    }
-
-    /// @notice TMP struct-based overload: full `TaxConfigs` (static tax + optional launch-tax decay) and a
-    ///         `creatorVaults` array (pass empty for none). `univ4Configs.lpFeeBps` selects the graduator/hook
-    ///         pair (100 or 50). Always uses `LiquidityTier.DEFAULT`.
-    /// @dev TEMPORARY: the tier-less overload existing frontends call while the liquidity-tier UI is not
-    ///      ready. Removed once the frontend adopts tiers; use the `TokenSetupTiered` overload below to
-    ///      select a tier.
-    function createToken(
-        TokenSetup calldata tokenSetup,
-        TaxConfigs calldata taxConfigs,
-        UniV4Configs calldata univ4Configs,
-        SupplyShare[] calldata buyOnDeployShares,
-        AntiSniperConfigs calldata antiSniperConfigs,
-        CreatorVault[] calldata creatorVaults
-    ) external payable returns (address token) {
-        _validateUniv4Configs(univ4Configs);
-        _validateTotalFee(univ4Configs.lpFeeBps, taxConfigs);
-        // Inline `tokenOwner`/`graduator` (rather than locals) to keep the stack shallow enough to compile
-        // without `via_ir`.
-        token = _createToken(
-            tokenSetup,
-            LiquidityTier.DEFAULT,
-            univ4Configs.renounceOwnership ? address(0) : msg.sender,
-            _resolveGraduator(univ4Configs.lpFeeBps, LiquidityTier.DEFAULT),
-            buyOnDeployShares,
-            taxConfigs,
-            antiSniperConfigs,
-            creatorVaults
-        );
-        emit LpFeeBpsSet(token, univ4Configs.lpFeeBps);
     }
 
     /// @notice Struct-based overload taking the full `TaxConfigs` (static tax + optional linear launch-tax
@@ -189,13 +159,9 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
         _validateUniv4Configs(univ4Configs);
         _validateTotalFee(univ4Configs.lpFeeBps, taxConfigs);
         // Inline `tokenOwner`/`graduator` (rather than locals) to keep the stack shallow enough to compile
-        // without `via_ir` — the extra `base` build pushes this overload over the limit otherwise.
-        TokenSetup memory base = TokenSetup({
-            name: tokenSetup.name, symbol: tokenSetup.symbol, salt: tokenSetup.salt, feeShares: tokenSetup.feeShares
-        });
+        // without `via_ir`.
         token = _createToken(
-            base,
-            tokenSetup.liquidityTier,
+            tokenSetup,
             univ4Configs.renounceOwnership ? address(0) : msg.sender,
             _resolveGraduator(univ4Configs.lpFeeBps, tokenSetup.liquidityTier),
             buyOnDeployShares,

--- a/src/factories/LivoFactoryUniV4Unified.sol
+++ b/src/factories/LivoFactoryUniV4Unified.sol
@@ -147,7 +147,8 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
     /// @notice Struct-based overload taking the full `TaxConfigs` (static tax + optional linear launch-tax
     ///         decay), a `creatorVaults` array (pass empty for none) and a `TokenSetupTiered` selecting the
     ///         liquidity tier. `univ4Configs.lpFeeBps` selects which graduator/hook pair to use (100 or 50).
-    ///         This is the current recommended overload.
+    ///         Kept for backwards compatibility; new integrations should use the `referral` overload below
+    ///         (the current recommended overload).
     function createToken(
         TokenSetupTiered calldata tokenSetup,
         TaxConfigs calldata taxConfigs,
@@ -170,6 +171,36 @@ contract LivoFactoryUniV4Unified is LivoFactoryAbstract {
             creatorVaults
         );
         emit LpFeeBpsSet(token, univ4Configs.lpFeeBps);
+    }
+
+    /// @notice Recommended overload: same as the `TokenSetupTiered` overload plus a `referral` address for
+    ///         relayers that forward the creation and are entitled to a cut of the fees. When `referral` is
+    ///         non-zero a `TokenReferral(token, referral)` event is emitted; no token storage or on-chain
+    ///         payout is wired to it yet — it is purely an off-chain signal for now.
+    function createToken(
+        TokenSetupTiered calldata tokenSetup,
+        TaxConfigs calldata taxConfigs,
+        UniV4Configs calldata univ4Configs,
+        SupplyShare[] calldata buyOnDeployShares,
+        AntiSniperConfigs calldata antiSniperConfigs,
+        CreatorVault[] calldata creatorVaults,
+        address referral
+    ) external payable returns (address token) {
+        _validateUniv4Configs(univ4Configs);
+        _validateTotalFee(univ4Configs.lpFeeBps, taxConfigs);
+        // Inline `tokenOwner`/`graduator` (rather than locals) to keep the stack shallow enough to compile
+        // without `via_ir`.
+        token = _createToken(
+            tokenSetup,
+            univ4Configs.renounceOwnership ? address(0) : msg.sender,
+            _resolveGraduator(univ4Configs.lpFeeBps, tokenSetup.liquidityTier),
+            buyOnDeployShares,
+            taxConfigs,
+            antiSniperConfigs,
+            creatorVaults
+        );
+        emit LpFeeBpsSet(token, univ4Configs.lpFeeBps);
+        if (referral != address(0)) emit TokenReferral(token, referral);
     }
 
     ///////////////////////// INTERNAL FUNCTIONS /////////////////////////

--- a/src/interfaces/ILivoFactory.sol
+++ b/src/interfaces/ILivoFactory.sol
@@ -116,6 +116,13 @@ interface ILivoFactory {
         address indexed token, uint256 totalVaultAllocation, address[] vaults, uint256[] amounts
     );
 
+    /// @notice Emitted when a token is created through the referral `createToken` overload with a
+    ///         non-zero `referral`. Records the relayer/referrer that forwarded the creation and is
+    ///         entitled to a cut of the fees. No on-chain payout or token storage is wired to this yet —
+    ///         it is purely an off-chain signal for now. Indexed on both fields so subscribers can filter
+    ///         by token or by referral (e.g. "all tokens referred by X").
+    event TokenReferral(address indexed token, address indexed referral);
+
     ////////////////// Errors //////////////////////
 
     error InvalidNameOrSymbol();

--- a/src/interfaces/ILivoFactory.sol
+++ b/src/interfaces/ILivoFactory.sol
@@ -62,23 +62,11 @@ interface ILivoFactory {
         uint256 vestingSeconds;
     }
 
-    /// @notice Token-identity bundle for the tier-less (tmp) struct-based `createToken` overload and the
-    ///         legacy positional overload. Groups the inputs that define the token itself (name, symbol,
-    ///         deterministic salt) and its fee receivers. `feeShares` must be non-empty — every token has
-    ///         at least one receiver. Tokens created through this struct always use `LiquidityTier.DEFAULT`.
-    /// @dev TEMPORARY: kept tier-less so existing frontends keep their `createToken` ABI while the
-    ///      liquidity-tier UI is not ready. Once the frontend adopts tiers, this struct is removed and
-    ///      `TokenSetupTiered` becomes the only setup struct.
-    struct TokenSetup {
-        string name;
-        string symbol;
-        bytes32 salt;
-        FeeShare[] feeShares;
-    }
-
-    /// @notice Token-identity bundle for the tiered struct-based `createToken` overload. Same fields as
-    ///         `TokenSetup` plus `liquidityTier`, which selects the post-graduation pool depth (and the
-    ///         tier-specific bonding curve + graduation marketcap).
+    /// @notice Token-identity bundle for the struct-based `createToken` overload. Groups the inputs that
+    ///         define the token itself (name, symbol, deterministic salt), its fee receivers and the
+    ///         `liquidityTier` selecting the post-graduation pool depth (and the tier-specific bonding
+    ///         curve + graduation marketcap). `feeShares` must be non-empty — every token has at least one
+    ///         receiver.
     /// @dev `liquidityTier`'s zero value is `LiquidityTier.THIN`, so set it explicitly.
     struct TokenSetupTiered {
         string name;

--- a/test/creatorVaults/creatorVaults.e2e.t.sol
+++ b/test/creatorVaults/creatorVaults.e2e.t.sol
@@ -44,11 +44,12 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
 
     /// @dev Creates a plain (non-tax, non-sniper) V4 token with the given vaults.
     function _createV4(ILivoFactory.CreatorVault[] memory vaults) internal returns (address token) {
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "Vault",
             symbol: "VLT",
             salt: _nextValidSalt(address(factoryV4Unified), address(livoToken)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
@@ -219,11 +220,12 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
 
     function test_sniperToken_vaultExceedsMaxWallet_stillFunded() public {
         // sniper config with a tiny max-wallet cap (0.5%); the 30% vault is 60x that cap.
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "VaultSniper",
             symbol: "VS",
             salt: _nextValidSalt(address(factoryV4Unified), address(livoTokenSniper)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
@@ -251,11 +253,12 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
     }
 
     function test_v2TaxToken_vaultFunding_notTaxed() public {
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "VaultTaxV2",
             symbol: "VTX",
             salt: _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
 
         vm.recordLogs();
@@ -385,11 +388,12 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
         // the 30% curve starts steeper, so the same tokens cost MORE ETH than the base quote
         assertGt(ethVaultAware, ethBaseOnly, "vault-aware quote must exceed the base quote");
 
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "VQ",
             symbol: "VQ",
             salt: _nextValidSalt(address(factoryV4Unified), address(livoToken)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
 
         vm.deal(creator, ethVaultAware);

--- a/test/creatorVaults/creatorVaults.e2e.t.sol
+++ b/test/creatorVaults/creatorVaults.e2e.t.sol
@@ -54,8 +54,9 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
         vm.prank(creator);
-        token =
-            factoryV4Unified.createToken(setup, _toCfgs(_emptyTaxCfg()), cfg, _noSs(), _emptyAntiSniperCfg(), vaults);
+        token = factoryV4Unified.createToken(
+            setup, _toCfgs(_emptyTaxCfg()), cfg, _noSs(), _emptyAntiSniperCfg(), vaults, address(0)
+        );
     }
 
     /// @dev Creates a token and returns the (single) deployed vault address by scanning logs.
@@ -239,7 +240,7 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
         vm.recordLogs();
         vm.prank(creator);
         address token = factoryV4Unified.createToken(
-            setup, _toCfgs(_emptyTaxCfg()), cfg, _noSs(), sniper, _one(_vault(vaultOwner, 3000, 0, 1 days))
+            setup, _toCfgs(_emptyTaxCfg()), cfg, _noSs(), sniper, _one(_vault(vaultOwner, 3000, 0, 1 days)), address(0)
         );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         address vault;
@@ -268,7 +269,8 @@ contract CreatorVaultsE2ETest is LaunchpadBaseTestsWithUniv4Graduator {
             _toCfgs(_taxCfg(300, 300, uint32(7 days))),
             _noSs(),
             _emptyAntiSniperCfg(),
-            _one(_vault(vaultOwner, 2000, 0, 1 days))
+            _one(_vault(vaultOwner, 2000, 0, 1 days)),
+            address(0)
         );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         address vault;

--- a/test/factories/LivoFactoryDeployerBuy.t.sol
+++ b/test/factories/LivoFactoryDeployerBuy.t.sol
@@ -447,8 +447,9 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
         );
 
         bytes32 salt = _nextValidSalt(address(factoryTax), address(livoTaxToken));
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "TestToken", symbol: "TEST", salt: salt, feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "TestToken", symbol: "TEST", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
 
         vm.prank(creator);
         address token = factoryTax.createToken{value: totalEthNeeded}(

--- a/test/factories/LivoFactoryDeployerBuy.t.sol
+++ b/test/factories/LivoFactoryDeployerBuy.t.sol
@@ -458,7 +458,8 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
             _univ4Cfg100(),
             _ss(creator),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
 
         uint256 creatorBalance = LivoTaxableTokenUniV4(payable(token)).balanceOf(creator);

--- a/test/factories/LivoFactoryUniV2Unified.t.sol
+++ b/test/factories/LivoFactoryUniV2Unified.t.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {Vm} from "forge-std/Vm.sol";
 import {LaunchpadBaseTestsWithUniv2Graduator} from "test/launchpad/base.t.sol";
 import {LivoFactoryUniV2Unified} from "src/factories/LivoFactoryUniV2Unified.sol";
 import {LivoToken} from "src/tokens/LivoToken.sol";
 import {AntiSniperConfigs} from "src/tokens/SniperProtection.sol";
 import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
+import {LiquidityTier} from "src/types/LiquidityTier.sol";
 
 /// @notice Dispatch + field-readback tests for `LivoFactoryUniV2Unified`. These non-tax tests lock
 ///         in dispatch between the base and anti-sniper implementations based on
@@ -150,5 +152,48 @@ contract LivoFactoryUniV2UnifiedTests is LaunchpadBaseTestsWithUniv2Graduator {
         vm.prank(creator);
         vm.expectRevert(ILivoFactory.InvalidFeeReceiver.selector);
         factoryV2Unified.createToken("T", "T", salt, _noFs(), _noSs(), _emptyTaxCfg(), _emptyAntiSniperCfg());
+    }
+
+    // ───────────── Referral overload ─────────────
+
+    function test_createToken_referral_emitsTokenReferral() public {
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoToken));
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "R", symbol: "R", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
+        address referral = makeAddr("relayer");
+        address expected = _predictToken(address(factoryV2Unified), address(livoToken), creator, salt);
+
+        vm.expectEmit(true, true, false, false);
+        emit ILivoFactory.TokenReferral(expected, referral);
+        vm.prank(creator);
+        address token = factoryV2Unified.createToken(
+            setup, _toCfgs(_emptyTaxCfg()), _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0), referral
+        );
+        assertEq(token, expected);
+    }
+
+    /// @dev A zero referral emits no `TokenReferral` (the common no-referral deploy stays quiet).
+    function test_createToken_zeroReferral_noTokenReferralEvent() public {
+        bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoToken));
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "R", symbol: "R", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
+
+        vm.recordLogs();
+        vm.prank(creator);
+        factoryV2Unified.createToken(
+            setup,
+            _toCfgs(_emptyTaxCfg()),
+            _noSs(),
+            _emptyAntiSniperCfg(),
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("TokenReferral(address,address)");
+        for (uint256 i; i < logs.length; ++i) {
+            assertTrue(logs[i].topics[0] != sig, "no TokenReferral for zero referral");
+        }
     }
 }

--- a/test/factories/LivoFactoryUniV4Unified.t.sol
+++ b/test/factories/LivoFactoryUniV4Unified.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
+import {Vm} from "forge-std/Vm.sol";
 import {LaunchpadBaseTestsWithUniv4Graduator} from "test/launchpad/base.t.sol";
 import {LiquidityTier} from "src/types/LiquidityTier.sol";
 import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
@@ -280,7 +281,8 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
             cfg,
             _noSs(),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
     }
 
@@ -299,7 +301,13 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
         emit ILivoFactory.LpFeeBpsSet(address(0), 50);
         vm.prank(creator);
         address token = factoryV4Unified.createToken(
-            setup, _toCfgs(_emptyTaxCfg()), cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0)
+            setup,
+            _toCfgs(_emptyTaxCfg()),
+            cfg,
+            _noSs(),
+            _emptyAntiSniperCfg(),
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
 
         // The pre-graduation LP fee the launchpad reads each trade is 1%, not the 0.5% hook fee.
@@ -325,7 +333,8 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
             cfg,
             _noSs(),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
     }
 
@@ -345,7 +354,8 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
             cfg,
             _noSs(),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
     }
 
@@ -459,5 +469,59 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
         factoryV4Unified.createToken(
             "T", "T", badSalt, _fs(creator), _noSs(), false, _taxCfg(0, 400, uint32(14 days)), _emptyAntiSniperCfg()
         );
+    }
+
+    // ───────────── Referral overload ─────────────
+
+    function test_createToken_referral_emitsTokenReferral() public {
+        bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoToken));
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "R", symbol: "R", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
+        LivoFactoryUniV4Unified.UniV4Configs memory cfg =
+            LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
+        address referral = makeAddr("relayer");
+        address expected = _predictToken(address(factoryV4Unified), address(livoToken), creator, salt);
+
+        vm.expectEmit(true, true, false, false);
+        emit ILivoFactory.TokenReferral(expected, referral);
+        vm.prank(creator);
+        address token = factoryV4Unified.createToken(
+            setup,
+            _toCfgs(_emptyTaxCfg()),
+            cfg,
+            _noSs(),
+            _emptyAntiSniperCfg(),
+            new ILivoFactory.CreatorVault[](0),
+            referral
+        );
+        assertEq(token, expected);
+    }
+
+    /// @dev A zero referral emits no `TokenReferral` (the common no-referral deploy stays quiet).
+    function test_createToken_zeroReferral_noTokenReferralEvent() public {
+        bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoToken));
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "R", symbol: "R", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
+        LivoFactoryUniV4Unified.UniV4Configs memory cfg =
+            LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
+
+        vm.recordLogs();
+        vm.prank(creator);
+        factoryV4Unified.createToken(
+            setup,
+            _toCfgs(_emptyTaxCfg()),
+            cfg,
+            _noSs(),
+            _emptyAntiSniperCfg(),
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("TokenReferral(address,address)");
+        for (uint256 i; i < logs.length; ++i) {
+            assertTrue(logs[i].topics[0] != sig, "no TokenReferral for zero referral");
+        }
     }
 }

--- a/test/factories/LivoFactoryUniV4Unified.t.sol
+++ b/test/factories/LivoFactoryUniV4Unified.t.sol
@@ -267,8 +267,9 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
     function test_createToken_struct_halfPercentLp_succeedsAtFourPointFivePercentTax() public {
         // 0.5% LP + 4.5% tax (buy and sell) == 5% total, the boundary.
         bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoTaxToken));
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: salt, feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "T", symbol: "T", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 50});
 
@@ -287,8 +288,9 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
         // A token that selects the 0.5% post-graduation hook still pays 1% LP on the bonding curve:
         // the pre-graduation launchpad LP fee is a fixed launchpad policy, decoupled from the hook fee.
         bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoToken));
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: salt, feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "T", symbol: "T", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 50});
 
@@ -309,8 +311,9 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
 
     function test_createToken_struct_halfPercentLp_revertsAboveFourPointFivePercentTax() public {
         // 0.5% LP + 4.51% sell tax == 5.01% total > 5%.
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 50});
 
@@ -328,8 +331,9 @@ contract LivoFactoryUniV4UnifiedTests is LaunchpadBaseTestsWithUniv4Graduator {
 
     function test_createToken_struct_onePercentLp_revertsAboveFourPercentTax() public {
         // 1% LP + 4.01% buy tax == 5.01% total > 5%, even though 4.01% is below the absolute cap.
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "T", symbol: "T", salt: "0x12", feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
         LivoFactoryUniV4Unified.UniV4Configs memory cfg =
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100});
 

--- a/test/factories/taxDecayFactory.t.sol
+++ b/test/factories/taxDecayFactory.t.sol
@@ -40,7 +40,7 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         address token = factoryV2Unified.createToken(
-            setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0)
+            setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0), address(0)
         );
 
         LivoTaxableTokenUniV2 t = LivoTaxableTokenUniV2(payable(token));
@@ -122,7 +122,7 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         address token = factoryV2Unified.createToken(
-            setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0)
+            setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0), address(0)
         );
 
         assertEq(_tax(token, true), 1000, "at launch, decay 10% dominates static 5%");
@@ -194,6 +194,8 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
 
         vm.prank(creator);
         vm.expectRevert(ILivoFactory.InvalidTaxBps.selector);
-        factoryV2Unified.createToken(setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0));
+        factoryV2Unified.createToken(
+            setup, cfg, _noSs(), _emptyAntiSniperCfg(), new ILivoFactory.CreatorVault[](0), address(0)
+        );
     }
 }

--- a/test/factories/taxDecayFactory.t.sol
+++ b/test/factories/taxDecayFactory.t.sol
@@ -34,8 +34,9 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
     function test_createToken_decayOnly_isTaxableCloneWithDecay() public {
         TaxConfigs memory cfg = _decayCfg(1000, 800, MAX_DECAY_DURATION, true);
         bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "D", symbol: "D", salt: salt, feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "D", symbol: "D", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
 
         vm.prank(creator);
         address token = factoryV2Unified.createToken(
@@ -115,8 +116,9 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
         // static 500 over 7 days + decay 1000 over 20min
         TaxConfigs memory cfg = _taxCfg(500, 500, uint32(7 days), true, 1000, 1000, MAX_DECAY_DURATION);
         bytes32 salt = _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2));
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "DS", symbol: "DS", salt: salt, feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "DS", symbol: "DS", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
 
         vm.prank(creator);
         address token = factoryV2Unified.createToken(
@@ -186,8 +188,9 @@ contract TaxDecayFactoryTests is LaunchpadBaseTestsWithUniv2Graduator {
         // same constraint enforced on the real deploy path, not just preview: sell decay (500) == sell
         // static (500) reverts even though buy decay (1000 > 500) is fine.
         TaxConfigs memory cfg = _taxCfg(500, 500, uint32(7 days), true, 1000, 500, MAX_DECAY_DURATION);
-        ILivoFactory.TokenSetup memory setup =
-            ILivoFactory.TokenSetup({name: "X", symbol: "X", salt: bytes32(0), feeShares: _fs(creator)});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "X", symbol: "X", salt: bytes32(0), feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
 
         vm.prank(creator);
         vm.expectRevert(ILivoFactory.InvalidTaxBps.selector);

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -685,7 +685,8 @@ contract TestGraduationWhileDecayActive is BaseUniswapV2GraduationTests {
             _decayCfg(1000, 1000, 20 minutes, true),
             _noSs(),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
         uniswapPair = LivoToken(testToken).pair();
 

--- a/test/graduators/graduationUniv2.t.sol
+++ b/test/graduators/graduationUniv2.t.sol
@@ -672,11 +672,12 @@ contract TestGraduationWhileDecayActive is BaseUniswapV2GraduationTests {
     function test_v2_graduatesWhileTaxDecayActive() public {
         uint40 t0 = uint40(block.timestamp);
         // decay-only token: 10%/10% buy/sell decay over the full 20min window, creation-anchored.
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "Decay",
             symbol: "DCY",
             salt: _nextValidSalt(address(factoryV2Unified), address(livoTaxTokenV2)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
         vm.prank(creator);
         testToken = factoryV2Unified.createToken(

--- a/test/graduators/taxToken.base.t.sol
+++ b/test/graduators/taxToken.base.t.sol
@@ -107,7 +107,8 @@ contract TaxTokenUniV4BaseTests is BaseUniswapV4GraduationTests {
             LivoFactoryUniV4Unified.UniV4Configs({renounceOwnership: false, lpFeeBps: 100}),
             _noSs(),
             _emptyAntiSniperCfg(),
-            new ILivoFactory.CreatorVault[](0)
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
         );
     }
 

--- a/test/graduators/taxToken.base.t.sol
+++ b/test/graduators/taxToken.base.t.sol
@@ -93,11 +93,12 @@ contract TaxTokenUniV4BaseTests is BaseUniswapV4GraduationTests {
         internal
         returns (address tokenAddress)
     {
-        ILivoFactory.TokenSetup memory setup = ILivoFactory.TokenSetup({
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
             name: "DecayToken",
             symbol: "DCY",
             salt: _nextValidSalt(address(factoryTax), address(livoTaxToken)),
-            feeShares: _fs(creator)
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
         });
         vm.prank(creator);
         tokenAddress = factoryTax.createToken(

--- a/test/graduators/tierGraduationPriceContinuity.t.sol
+++ b/test/graduators/tierGraduationPriceContinuity.t.sol
@@ -348,9 +348,9 @@ contract TierGraduationPriceContinuityTest is BaseUniswapV4GraduationTests {
         AntiSniperConfigs memory sniperCfg = _sniperCfgFor(flavor);
         vm.prank(creator);
         if (isV4) {
-            token = factoryV4Unified.createToken(setup, _toCfgs(taxCfg), _cfg(), _noSs(), sniperCfg, vaults);
+            token = factoryV4Unified.createToken(setup, _toCfgs(taxCfg), _cfg(), _noSs(), sniperCfg, vaults, address(0));
         } else {
-            token = factoryV2Unified.createToken(setup, _toCfgs(taxCfg), _noSs(), sniperCfg, vaults);
+            token = factoryV2Unified.createToken(setup, _toCfgs(taxCfg), _noSs(), sniperCfg, vaults, address(0));
         }
     }
 

--- a/test/graduators/tierLiquidityMatrix.t.sol
+++ b/test/graduators/tierLiquidityMatrix.t.sol
@@ -95,7 +95,7 @@ contract TierLiquidityMatrixTest is LaunchpadBaseTestsWithUniv4Graduator {
         if (value > 0) vm.deal(creator, value);
         vm.prank(creator);
         token = factoryV4Unified.createToken{value: value}(
-            setup, _toCfgs(_emptyTaxCfg()), _cfg(), ss, _emptyAntiSniperCfg(), vaults
+            setup, _toCfgs(_emptyTaxCfg()), _cfg(), ss, _emptyAntiSniperCfg(), vaults, address(0)
         );
     }
 


### PR DESCRIPTION
## Summary

Two related changes to the unified factory `createToken` surface, plus the deployment record + docs.

### 1. Collapse the tier-less overload (`f340937`)
Removes the TMP tier-less struct-based `createToken` overload from both factories. As a consequence, the `TokenSetup` struct is no longer an external ABI type, so it's folded away entirely — `TokenSetupTiered` becomes the only setup struct:
- `_createToken` takes `TokenSetupTiered memory` and reads `tokenSetup.liquidityTier` (drops its separate `LiquidityTier` param).
- Legacy overloads build a `TokenSetupTiered{…, liquidityTier: DEFAULT}`; tiered overloads pass the calldata struct straight through, dropping the `base` memory rebuild (shallower stack; still compiles without `via_ir`).

### 2. Add a referral `createToken` overload (`2a0084b`)
New **third** overload per factory = the `TokenSetupTiered` overload + a trailing `address referral`, for relayers that forward the creation and are entitled to a cut of the fees. When `referral != address(0)` it emits a new shared `ILivoFactory.TokenReferral(token, referral)` event (both indexed), last of all factory events.

- **`address`, not `bytes32`** — the fee cut is meant to be paid directly to the address later; you can't pay a `bytes32` without a registry.
- **No token storage or on-chain payout** wired to it yet — purely an off-chain signal for now, per scope.
- Existing two overloads untouched; the tiered no-referral overload stays for backwards compat.

### 3. Deployment + docs (`7d3f0a1`, `ab453d6`)
- Point `FACTORY_UNIV{2,4}_UNIFIED_IMPL` at the freshly deployed referral impls on **mainnet + sepolia** (proxies unchanged), regenerate `deployments.<chain>.md`.
- Add a recommended-overload guide under `docs/`.

## Testing
`just fast-test`: **1147 passed, 0 failed, 10 skipped**. Includes new dedicated referral-event tests in both factory suites (non-zero referral emits `TokenReferral` with the predicted token address; zero referral emits nothing). All struct-overload test call sites migrated to the new overload with `address(0)` (no behaviour change).

## Notes for reviewers
- **ABI change:** removing the tier-less overload drops a function selector — integrators on that signature must move to the legacy or tiered/referral overload.
- **Upgrade is storage-safe:** the referral change adds only an external function + event, no new storage. `LivoFactoryAbstract`'s "empty + 50-slot gap" layout is unchanged; the sepolia/mainnet proxies were upgraded in place via `RedeployUnifiedFactoriesOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)