### PR TITLE
feat(ops): unfunded-creator check covers Robinhood + tighter rules

### DIFF
--- a/justfile
+++ b/justfile
@@ -264,6 +264,48 @@ _rollback-unified rpc v2proxy v4proxy:
     done
     echo "Done. Reminder: if keeping this, update FACTORY_UNIV{2,4}_UNIFIED_IMPL in src/config/manifest.<chain>.sol and run 'just export-deployments'."
 
+##################### ROLLBACK — Robinhood (unified factory proxies) #######################
+# Same break-glass rollback as `rollback-mainnet`, but Robinhood is on Blockscout, not Etherscan,
+# so the previous impl is read from the node via `cast logs` (fresh L2 → full-range getLogs is cheap)
+# instead of the Etherscan API. Broadcaster must be the proxy owner (livo.dev). Same guards; mainnet
+# (chain 4663) asks to confirm. Manifest is NOT auto-edited — see the note under `rollback-mainnet`.
+rollback-robinhood:
+    just _rollback-unified-rpclogs "$ROBINHOOD_RPC_URL" 0x7843203be233b3Be7E5017A68a64FdBf32b45fFE 0xb637800Dcd5c83913D828E961dBB964A9896f19d
+
+rollback-robinhood-testnet:
+    just _rollback-unified-rpclogs "$ROBINHOOD_TESTNET_RPC_URL" 0xc0dE7109626A458dE1E0Ff06106830beD96DE971 0xfBa7137768E53f3B6a0d2333F41C44BaC7161FA0
+
+_rollback-unified-rpclogs rpc v2proxy v4proxy:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    RPC='{{rpc}}'
+    CHAINID=$(cast chain-id --rpc-url "$RPC")
+    declare -a TARGETS=()
+    echo "Chain $CHAINID — discovering previous implementations (proxy : current -> previous):"
+    for PROXY in {{v2proxy}} {{v4proxy}}; do
+        LP=$(cast call --rpc-url "$RPC" "$PROXY" 'LAUNCHPAD()(address)')
+        LOGS=$(cast logs --rpc-url "$RPC" --from-block 0 --to-block latest 'Upgraded(address)' --address "$PROXY" --json)
+        N=$(echo "$LOGS" | jq 'length')
+        [ "$N" -ge 2 ] || { echo "❌ $PROXY: only $N Upgraded events; no previous impl"; exit 1; }
+        PREV=$(echo "$LOGS" | jq -r '.[-2].topics[1]'); PREV="0x${PREV: -40}"
+        CURR=$(echo "$LOGS" | jq -r '.[-1].topics[1]'); CURR="0x${CURR: -40}"
+        [ "$(cast code --rpc-url "$RPC" "$PREV")" != "0x" ] || { echo "❌ prev impl $PREV has no bytecode"; exit 1; }
+        PLP=$(cast call --rpc-url "$RPC" "$PREV" 'LAUNCHPAD()(address)')
+        [ "${PLP,,}" = "${LP,,}" ] || { echo "❌ prev impl $PREV wired to $PLP, not proxy launchpad $LP — refusing"; exit 1; }
+        echo "  $PROXY : $CURR -> $PREV"
+        TARGETS+=("$PROXY=$PREV")
+    done
+    if [ "$CHAINID" = "4663" ]; then
+        read -r -p "Broadcast these ROBINHOOD MAINNET rollbacks? type 'yes': " ok
+        [ "$ok" = "yes" ] || { echo "aborted"; exit 1; }
+    fi
+    for t in "${TARGETS[@]}"; do
+        PROXY="${t%%=*}"; PREV="${t##*=}"
+        cast send --rpc-url "$RPC" --account livo.dev "$PROXY" 'upgradeToAndCall(address,bytes)' "$PREV" 0x
+        echo "✔ $PROXY rolled back to $PREV"
+    done
+    echo "Done. Reminder: if keeping this, update FACTORY_UNIV{2,4}_UNIFIED_IMPL in src/config/manifest.robinhood.<net>.sol and run 'just export-deployments'."
+
 create-token-v2 tokenName value="0":
     SALT=$(just next-salt {{factoryV2}}) && echo "Using salt: $SALT" && \
         cast send --rpc-url $SEPOLIA_RPC_URL --account livo.dev {{factoryV2}} \

--- a/script/operations/unfunded-accounts/check_unfunded_creators.py
+++ b/script/operations/unfunded-accounts/check_unfunded_creators.py
@@ -25,8 +25,12 @@ from rich.table import Table
 GRAPHQL_URL = "https://indexer.livo.trade/v1/graphql"
 JSONRPC_BATCH_SIZE = 100
 HTTP_TIMEOUT = 30
-MIN_BALANCE_WEI = 10**15  # 0.001 ETH
-MIN_ACCRUED_WEI = 10**16  # 0.01 ETH: ignore dust claims not worth funding gas for
+MIN_ACCRUED_WEI = 5 * 10**16  # 0.05 ETH: ignore dust claims not worth funding gas for
+
+# We flag a creator only when ALL three hold on the chain where they accrued:
+#   1. total accrued > MIN_ACCRUED_WEI
+#   2. never claimed anything on that chain (they don't know how to claim yet)
+#   3. exactly 0 ETH balance (any balance means they have gas / have held ETH before)
 
 # Chains to check. rpc_default lets Robinhood work without a configured secret (public RPC).
 CHAINS = [
@@ -39,16 +43,19 @@ CHAINS = [
     },
 ]
 
+# No claimedEth filter here: rows are per-token, so we must aggregate every token a
+# creator has on the chain to know whether they have EVER claimed. Filtering rows by
+# claimedEth == 0 would keep a creator who claimed on one token but not another.
 QUERY = """
 query MyQuery {{
   RewardsTokenCreator(
     where: {{
       chainId: {{_eq: "{chain_id}"}},
-      accountedEth: {{_gt: "0"}},
-      claimedEth: {{_eq: "0"}}
+      accountedEth: {{_gt: "0"}}
     }}
   ) {{
     accruedEth
+    claimedEth
     creator
   }}
 }}
@@ -69,12 +76,13 @@ def fetch_creators(chain_id: str) -> list[dict]:
     return payload["data"]["RewardsTokenCreator"]
 
 
-def unique_creators(rows: list[dict]) -> dict[str, int]:
-    """Return {lowercased address: total accruedEth in wei}."""
-    totals: dict[str, int] = {}
+def unique_creators(rows: list[dict]) -> dict[str, tuple[int, int]]:
+    """Return {lowercased address: (total accruedEth, total claimedEth) in wei}."""
+    totals: dict[str, tuple[int, int]] = {}
     for row in rows:
         addr = row["creator"].lower()
-        totals[addr] = totals.get(addr, 0) + int(row["accruedEth"])
+        accrued, claimed = totals.get(addr, (0, 0))
+        totals[addr] = (accrued + int(row["accruedEth"]), claimed + int(row["claimedEth"]))
     return totals
 
 
@@ -120,16 +128,21 @@ def main() -> int:
             continue
         try:
             console.print(f"[dim]{name}: querying Livo indexer…[/dim]")
-            accrued_by_addr = unique_creators(fetch_creators(chain["chain_id"]))
-            addresses = list(accrued_by_addr.keys())
-            console.print(f"[dim]{name}: {len(addresses)} unique creators with pending claims.[/dim]")
-            if not addresses:
+            totals = unique_creators(fetch_creators(chain["chain_id"]))
+            # Rules 1 & 2: enough accrued and never claimed on this chain.
+            candidates = {
+                addr: accrued
+                for addr, (accrued, claimed) in totals.items()
+                if accrued > MIN_ACCRUED_WEI and claimed == 0
+            }
+            console.print(f"[dim]{name}: {len(candidates)} creators with unclaimed rewards ≥ 0.05 ETH.[/dim]")
+            if not candidates:
                 continue
-            console.print(f"[dim]{name}: reading balances ({len(addresses)} wallets, batched)…[/dim]")
-            balances = get_balances(addresses, rpc_url)
-            for addr in addresses:
-                if balances[addr] < MIN_BALANCE_WEI and accrued_by_addr[addr] > MIN_ACCRUED_WEI:
-                    unfunded.append((name, addr, balances[addr], accrued_by_addr[addr]))
+            console.print(f"[dim]{name}: reading balances ({len(candidates)} wallets, batched)…[/dim]")
+            balances = get_balances(list(candidates), rpc_url)
+            for addr, accrued in candidates.items():
+                if balances[addr] == 0:  # Rule 3: exactly 0 ETH means no gas and never held ETH.
+                    unfunded.append((name, addr, balances[addr], accrued))
         except Exception as e:  # noqa: BLE001 — keep going so the other chain still gets checked
             errors.append(f"{name}: {e}")
             console.print(f"[red]{name}: error — {e}[/red]")
@@ -137,7 +150,7 @@ def main() -> int:
     unfunded.sort(key=lambda x: x[3], reverse=True)
 
     if unfunded:
-        table = Table(title=f"Unfunded creators (balance < 0.001 ETH): {len(unfunded)}")
+        table = Table(title=f"Unfunded creators (0 ETH balance, unclaimed ≥ 0.05 ETH): {len(unfunded)}")
         table.add_column("chain", style="magenta", no_wrap=True)
         table.add_column("creator", style="cyan", no_wrap=True)
         table.add_column("balance (ETH)", justify="right")
@@ -157,7 +170,7 @@ def main() -> int:
             per_chain[chain_name] = per_chain.get(chain_name, 0) + 1
         breakdown = ", ".join(f"{n} on {c}" for c, n in per_chain.items())
         parts.append(
-            f"{len(unfunded)} creator(s) have pending ETH claims but a balance below 0.001 ETH "
+            f"{len(unfunded)} creator(s) have ≥ 0.05 ETH unclaimed, never claimed, and a 0 ETH balance "
             f"({breakdown}) — fund them or investigate."
         )
     if errors:

--- a/script/operations/unfunded-accounts/check_unfunded_creators.py
+++ b/script/operations/unfunded-accounts/check_unfunded_creators.py
@@ -4,10 +4,11 @@
 # ///
 """Daily alert: fail if any Livo reward creator has pending ETH claims but a 0 ETH wallet.
 
-Runs in CI via .github/workflows/check-unfunded-creators.yml. On match, exits 1 so
-GitHub fires the standard workflow-failed email. Locally, runnable with
-`uv run check_unfunded_creators.py` after exporting MAINNET_RPC_URL (or putting it
-in a sibling .env file).
+Checks both Ethereum mainnet and Robinhood Chain mainnet. Runs in CI via
+.github/workflows/check-unfunded-creators.yml. On match, exits 1 so GitHub fires the
+standard workflow-failed email. Locally, runnable with `uv run check_unfunded_creators.py`
+after exporting MAINNET_RPC_URL (Robinhood defaults to its public RPC; override with
+ROBINHOOD_RPC_URL). Env vars can also live in a sibling .env file.
 """
 
 from __future__ import annotations
@@ -27,26 +28,39 @@ HTTP_TIMEOUT = 30
 MIN_BALANCE_WEI = 10**15  # 0.001 ETH
 MIN_ACCRUED_WEI = 10**16  # 0.01 ETH: ignore dust claims not worth funding gas for
 
+# Chains to check. rpc_default lets Robinhood work without a configured secret (public RPC).
+CHAINS = [
+    {"name": "ethereum", "chain_id": "1", "rpc_env": "MAINNET_RPC_URL", "rpc_default": None},
+    {
+        "name": "robinhood",
+        "chain_id": "4663",
+        "rpc_env": "ROBINHOOD_RPC_URL",
+        "rpc_default": "https://rpc.mainnet.chain.robinhood.com",
+    },
+]
+
 QUERY = """
-query MyQuery {
+query MyQuery {{
   RewardsTokenCreator(
-    where: {
-      chainId: {_eq: "1"},
-      accountedEth: {_gt: "0"},
-      claimedEth: {_eq: "0"}
-    }
-  ) {
+    where: {{
+      chainId: {{_eq: "{chain_id}"}},
+      accountedEth: {{_gt: "0"}},
+      claimedEth: {{_eq: "0"}}
+    }}
+  ) {{
     accruedEth
     creator
-  }
-}
+  }}
+}}
 """
 
 console = Console(highlight=False)
 
 
-def fetch_creators() -> list[dict]:
-    resp = requests.post(GRAPHQL_URL, json={"query": QUERY}, timeout=HTTP_TIMEOUT)
+def fetch_creators(chain_id: str) -> list[dict]:
+    resp = requests.post(
+        GRAPHQL_URL, json={"query": QUERY.format(chain_id=chain_id)}, timeout=HTTP_TIMEOUT
+    )
     if resp.status_code != 200:
         raise RuntimeError(f"GraphQL HTTP {resp.status_code}: {resp.text}")
     payload = resp.json()
@@ -93,44 +107,62 @@ def get_balances(addresses: list[str], rpc_url: str) -> dict[str, int]:
 
 def main() -> int:
     load_dotenv(Path(__file__).resolve().parent / ".env")
-    rpc_url = os.getenv("MAINNET_RPC_URL")
-    if not rpc_url:
-        console.print("[red]MAINNET_RPC_URL not set[/red]")
-        return 2
 
-    console.print("[dim]Querying Livo indexer…[/dim]")
-    rows = fetch_creators()
-    accrued_by_addr = unique_creators(rows)
-    console.print(
-        f"[dim]Indexer returned {len(rows)} rows → {len(accrued_by_addr)} unique creators.[/dim]"
-    )
+    unfunded: list[tuple[str, str, int, int]] = []  # (chain, addr, balance_wei, accrued_wei)
+    errors: list[str] = []  # per-chain failures, reported at the end so one bad chain doesn't hide the other
 
-    addresses = list(accrued_by_addr.keys())
-    console.print(f"[dim]Reading mainnet balances ({len(addresses)} wallets, batched)…[/dim]")
-    balances = get_balances(addresses, rpc_url)
+    for chain in CHAINS:
+        name = chain["name"]
+        rpc_url = os.getenv(chain["rpc_env"]) or chain["rpc_default"]
+        if not rpc_url:
+            errors.append(f"{name}: {chain['rpc_env']} not set")
+            console.print(f"[red]{name}: {chain['rpc_env']} not set — skipping[/red]")
+            continue
+        try:
+            console.print(f"[dim]{name}: querying Livo indexer…[/dim]")
+            accrued_by_addr = unique_creators(fetch_creators(chain["chain_id"]))
+            addresses = list(accrued_by_addr.keys())
+            console.print(f"[dim]{name}: {len(addresses)} unique creators with pending claims.[/dim]")
+            if not addresses:
+                continue
+            console.print(f"[dim]{name}: reading balances ({len(addresses)} wallets, batched)…[/dim]")
+            balances = get_balances(addresses, rpc_url)
+            for addr in addresses:
+                if balances[addr] < MIN_BALANCE_WEI and accrued_by_addr[addr] > MIN_ACCRUED_WEI:
+                    unfunded.append((name, addr, balances[addr], accrued_by_addr[addr]))
+        except Exception as e:  # noqa: BLE001 — keep going so the other chain still gets checked
+            errors.append(f"{name}: {e}")
+            console.print(f"[red]{name}: error — {e}[/red]")
 
-    unfunded = [
-        (addr, balances[addr], accrued_by_addr[addr])
-        for addr in addresses
-        if balances[addr] < MIN_BALANCE_WEI and accrued_by_addr[addr] > MIN_ACCRUED_WEI
-    ]
-    unfunded.sort(key=lambda x: x[2], reverse=True)
+    unfunded.sort(key=lambda x: x[3], reverse=True)
 
-    if not unfunded:
-        console.print("[green]OK: no unfunded creators with pending claims.[/green]")
+    if unfunded:
+        table = Table(title=f"Unfunded creators (balance < 0.001 ETH): {len(unfunded)}")
+        table.add_column("chain", style="magenta", no_wrap=True)
+        table.add_column("creator", style="cyan", no_wrap=True)
+        table.add_column("balance (ETH)", justify="right")
+        table.add_column("accrued (ETH)", justify="right", style="green")
+        for chain_name, addr, bal_wei, accrued_wei in unfunded:
+            table.add_row(chain_name, addr, f"{bal_wei / 1e18:.6f}", f"{accrued_wei / 1e18:.6f}")
+        console.print(table)
+
+    if not unfunded and not errors:
+        console.print("[green]OK: no unfunded creators with pending claims on any chain.[/green]")
         return 0
 
-    table = Table(title=f"Unfunded creators (balance < 0.001 ETH): {len(unfunded)}")
-    table.add_column("creator", style="cyan", no_wrap=True)
-    table.add_column("balance (ETH)", justify="right")
-    table.add_column("accrued (ETH)", justify="right", style="green")
-    for addr, bal_wei, accrued_wei in unfunded:
-        table.add_row(addr, f"{bal_wei / 1e18:.6f}", f"{accrued_wei / 1e18:.6f}")
-    console.print(table)
-
-    raise RuntimeError(
-        f"{len(unfunded)} creator(s) have pending ETH claims but a balance below 0.001 ETH — fund them or investigate."
-    )
+    parts: list[str] = []
+    if unfunded:
+        per_chain: dict[str, int] = {}
+        for chain_name, *_ in unfunded:
+            per_chain[chain_name] = per_chain.get(chain_name, 0) + 1
+        breakdown = ", ".join(f"{n} on {c}" for c, n in per_chain.items())
+        parts.append(
+            f"{len(unfunded)} creator(s) have pending ETH claims but a balance below 0.001 ETH "
+            f"({breakdown}) — fund them or investigate."
+        )
+    if errors:
+        parts.append("Chain errors: " + "; ".join(errors))
+    raise RuntimeError(" | ".join(parts))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Extends `script/operations/unfunded-accounts/check_unfunded_creators.py` to check **both Ethereum mainnet (chain 1) and Robinhood Chain mainnet (chain 4663)**, and tightens the rules for what counts as an "unfunded" creator.

## Changes

- **Multi-chain**: loops over both chains, tags each flagged creator with its chain in the output table, and collects results across both chains before failing — so one chain's issues don't hide the other's. Robinhood defaults to its public RPC (`https://rpc.mainnet.chain.robinhood.com`, override with `ROBINHOOD_RPC_URL`), so CI works with no workflow change.
- **Tighter flagging rules** — a creator is flagged only when all three hold on the chain where they accrued:
  1. total accrued ≥ 0.05 ETH
  2. never claimed anything on that chain (aggregates `claimedEth` across all per-token rows — the entity is keyed `{chainId}_{token}_{creator}`, so a row-level `claimedEth == 0` filter would wrongly keep a creator who claimed on one token but not another)
  3. exactly 0 ETH balance (any non-zero balance means they have gas / have held ETH before; any prior claim means they know how to claim)

## Testing

Ran locally against the live indexer + RPCs: both chains queried, zero false positives from dust-balance accounts.