### PR TITLE
feat(factories): remove deploy-buy 10% cap, bound only by graduation

### DIFF
--- a/abis/LivoFactoryUniV2Unified.json
+++ b/abis/LivoFactoryUniV2Unified.json
@@ -1036,11 +1036,22 @@
   },
   {
     "type": "function",
-    "name": "maxBuyOnDeployBps",
-    "inputs": [],
+    "name": "maxBuyOnDeploy",
+    "inputs": [
+      {
+        "name": "tier",
+        "type": "uint8",
+        "internalType": "enum LiquidityTier"
+      },
+      {
+        "name": "totalLockedInVaultsBps",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "outputs": [
       {
-        "name": "",
+        "name": "maxTokens",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -1595,11 +1606,6 @@
   {
     "type": "error",
     "name": "InvalidAntiSniperConfig",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidBuyOnDeploy",
     "inputs": []
   },
   {

--- a/abis/LivoFactoryUniV4Unified.json
+++ b/abis/LivoFactoryUniV4Unified.json
@@ -1179,11 +1179,22 @@
   },
   {
     "type": "function",
-    "name": "maxBuyOnDeployBps",
-    "inputs": [],
+    "name": "maxBuyOnDeploy",
+    "inputs": [
+      {
+        "name": "tier",
+        "type": "uint8",
+        "internalType": "enum LiquidityTier"
+      },
+      {
+        "name": "totalLockedInVaultsBps",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
     "outputs": [
       {
-        "name": "",
+        "name": "maxTokens",
         "type": "uint256",
         "internalType": "uint256"
       }
@@ -1755,11 +1766,6 @@
   {
     "type": "error",
     "name": "InvalidAntiSniperConfig",
-    "inputs": []
-  },
-  {
-    "type": "error",
-    "name": "InvalidBuyOnDeploy",
     "inputs": []
   },
   {

--- a/deployments.ethereum.mainnet.md
+++ b/deployments.ethereum.mainnet.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x93AcF08eE9bABa0672bd1ae668dEbb5d9fdfE354` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x79ab23C9f95D8B7ae96EA789F20a81A945C7cca9` |
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
-| LivoFactoryUniV2Unified (impl)               | `0x03AfF3484c04BeD2B2eA63b55475F03318eF7EA9` |
+| LivoFactoryUniV2Unified (impl)               | `0x25A30503E2680CEDA6fa5b5d966Bc2219C37F464` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0x178A14654D080450e5Cf11b8f6114c6280Df7828` |
+| LivoFactoryUniV4Unified (impl)               | `0x81597b85f2C760d0960C84E4DAd8a5b4E9EeF0A5` |
 | LivoCreatorVaultFactory (proxy)              | `0xA06f07bf255cB63c694339F172f9459f3BF015E7` |
 | LivoCreatorVaultFactory (impl)               | `0x4b387716EbA7498Eb757467A876FAA98733A329e` |
 | LivoCreatorVault (impl)                      | `0xcad4C889e0897BF3fdeE367F402F728342651603` |

--- a/deployments.ethereum.sepolia.md
+++ b/deployments.ethereum.sepolia.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x61054ec92636c2e4eE1ecE05F7F9bE7D240F24dA` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x76bA7d2d05b76CA78bF7504ede5c2E607Acfc328` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0x174a043E00C527e3D1a8e0bc19fE1E15e4e859f6` |
+| LivoFactoryUniV2Unified (impl)               | `0x2Fb8Bf5df18F215e22D9D91A82cE6D5Dd8121De3` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0x8ED7408Def91C96E7C76df3FA9B3a15918E5b1bd` |
+| LivoFactoryUniV4Unified (impl)               | `0x17E8AD9f793b63C60725051eE4048928eCD2171F` |
 | LivoCreatorVaultFactory (proxy)              | `0x804ad45394FCF755350d924f712EC463E5E3147D` |
 | LivoCreatorVaultFactory (impl)               | `0xcbeBF86091de0E2c5d18D6c4E3d44e44855C2C47` |
 | LivoCreatorVault (impl)                      | `0xe5aF8d840963060302cf5021630d6dBF41a9e07b` |

--- a/deployments.robinhood.mainnet.md
+++ b/deployments.robinhood.mainnet.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x8f186be8A2f40fE87F27D8F15f86058bD3d5C481` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x463b51ee8F4e5F551C9A87B26ff1Fe8a1245Dd17` |
 | LivoFactoryUniV2Unified (proxy)              | `0x7843203be233b3Be7E5017A68a64FdBf32b45fFE` |
-| LivoFactoryUniV2Unified (impl)               | `0x12947f43652BE26d7b418f0cEe3fE73259805222` |
+| LivoFactoryUniV2Unified (impl)               | `0xdA15442dCe5C2356C0b42d67DAc606C3dc2f4356` |
 | LivoFactoryUniV4Unified (proxy)              | `0xb637800Dcd5c83913D828E961dBB964A9896f19d` |
-| LivoFactoryUniV4Unified (impl)               | `0xDBfa01630382e88268df8AE00476e03eE2da1Af7` |
+| LivoFactoryUniV4Unified (impl)               | `0xCBe739C13a031c446617f0722FDC081b9298979b` |
 | LivoCreatorVaultFactory (proxy)              | `0xBa1a7Fe65E7aAb563630F5921080996030a80AA1` |
 | LivoCreatorVaultFactory (impl)               | `0xf5E30BE2b72b0dEbCD85103AdaE399CbC3046Fcf` |
 | LivoCreatorVault (impl)                      | `0xE735d281d313AD09bd8bFF81F181715b6c6aD772` |

--- a/deployments.robinhood.testnet.md
+++ b/deployments.robinhood.testnet.md
@@ -19,9 +19,9 @@
 | LivoTaxableTokenUniV4 (impl)                 | `0x812Cc2479174d1BA07Bb8788A09C6fe6dCD20e33` |
 | LivoTaxableTokenUniV2 (impl)                 | `0x035693207fb473358b41A81FF09445dB1f3889D1` |
 | LivoFactoryUniV2Unified (proxy)              | `0xc0dE7109626A458dE1E0Ff06106830beD96DE971` |
-| LivoFactoryUniV2Unified (impl)               | `0xEA528f484d5Af6ba0CDFcb569699CB7B9c9c5f38` |
+| LivoFactoryUniV2Unified (impl)               | `0x97BF1fC5Ee72Dd8c9686386ff00c99b6e3b9C00D` |
 | LivoFactoryUniV4Unified (proxy)              | `0xfBa7137768E53f3B6a0d2333F41C44BaC7161FA0` |
-| LivoFactoryUniV4Unified (impl)               | `0x014E675AA4ae0434b0840C177BAA454582aacF75` |
+| LivoFactoryUniV4Unified (impl)               | `0xD8Ccee63514E8B0862f9E0fF82223b2DCa943936` |
 | LivoCreatorVaultFactory (proxy)              | `0x7BA7523E87a07514Ec059D233AefbDED0C21833B` |
 | LivoCreatorVaultFactory (impl)               | `0x76f404dDcbc6E3ff466F983121CC2b0D8a63F4cb` |
 | LivoCreatorVault (impl)                      | `0xd1B50918Aa2e34b89A89B23C84d2377F1622d0f6` |

--- a/docs/create-token-recommended-overload.md
+++ b/docs/create-token-recommended-overload.md
@@ -104,10 +104,13 @@ across these recipients.
 
 Rules:
 - `msg.value == 0` ⇔ `buyOnDeployShares.length == 0` (pass one without the other → revert).
-- Aggregate tokens bought must be `≤ maxBuyOnDeployBps` = **1_000 bps (10%)** of supply. This is on the
-  aggregate — splitting across recipients does not bypass it.
-- Use `quoteBuyOnDeploy(liquidityTier, tokenAmount, totalLockedInVaultsBps, taxCfg[, univ4Configs])`
-  to compute the `msg.value` for a target token amount. It does **not** enforce the 10% cap — that's on you.
+- There is **no** buy-on-deploy cap: the deploy buy is bounded only by graduation. A buy whose ETH would
+  push the curve past `graduationThreshold + maxExcessOverThreshold` reverts `MaxEthReservesExceeded`; a buy
+  that reaches the threshold **graduates the token in the same tx**.
+- Use `maxBuyOnDeploy(liquidityTier, totalLockedInVaultsBps)` for the max token amount that reaches
+  graduation without tripping that revert, then
+  `quoteBuyOnDeploy(liquidityTier, tokenAmount, totalLockedInVaultsBps, taxCfg[, univ4Configs])`
+  to compute the `msg.value` for a target token amount.
 
 ### `antiSniperConfigs` — `AntiSniperConfigs`
 
@@ -156,7 +159,7 @@ All errors are 4-byte custom errors.
 | `InvalidShares` | any `shares == 0`, or `feeShares` / `buyOnDeployShares` sum ≠ `10_000`. |
 | `MultipleDirectFeeReceivers` | more than one `feeShares` entry with `directFeesEnabled == true`. |
 | `InvalidSupplyShares` | `msg.value` and `buyOnDeployShares.length` disagree (one zero, one not); or zero/duplicate accounts. |
-| `InvalidBuyOnDeploy` | aggregate buy-on-deploy > 10% of supply. |
+| `MaxEthReservesExceeded` | deploy buy exceeds graduation (`graduationThreshold + maxExcessOverThreshold`); size it with `maxBuyOnDeploy`. |
 | `InvalidTaxConfig` | tax sentinel mismatch: `taxDurationSeconds == 0` with non-zero bps (or vice-versa); or `taxDecayDuration == 0` with non-zero decay-start bps (or vice-versa). |
 | `InvalidTaxBps` | `lpFeeBps + buyTaxBps` or `lpFeeBps + sellTaxBps` > `500`; combined decay start > `2_000`; or a decay start ≤ its direction's static rate. |
 | `InvalidTaxDuration` | `taxDurationSeconds` > 120 years; `taxDecayDuration` > 20 min; or (both set) `taxDurationSeconds < taxDecayDuration`. |

--- a/docs/external/factory-createToken-integration.md
+++ b/docs/external/factory-createToken-integration.md
@@ -90,7 +90,7 @@ struct AntiSniperConfigs {
 
 1. Build the exact `(feeReceivers, supplyShares, taxCfg, antiSniperCfg)` you intend to submit. For V4 also decide `renounceOwnership_`.
 2. Call `factory.previewTokenImplementation(feeReceivers, supplyShares, taxCfg, antiSniperCfg)` (view). This runs the same validation as `createToken` for the tax and anti-sniper sentinels, and returns the implementation that will be cloned. The V4 `renounceOwnership_` flag is **not** an input — preview always assumes the renounced path. If you intend to keep ownership, the charity-mode owner check in `createToken` will fire only at submit time.
-3. (Optional) If `msg.value > 0`, call `factory.quoteBuyOnDeploy(tokenAmount)` to get the ETH amount that yields exactly `tokenAmount` tokens after the launchpad buy fee. The quote does **not** check against `maxBuyOnDeployBps` — that's on you.
+3. (Optional) If `msg.value > 0`, call `factory.quoteBuyOnDeploy(tokenAmount)` to get the ETH amount that yields exactly `tokenAmount` tokens after the launchpad buy fee. The deploy buy is uncapped except by graduation — call `factory.maxBuyOnDeploy(liquidityTier, totalLockedInVaultsBps)` for the max token amount that reaches graduation without reverting `MaxEthReservesExceeded`.
 4. Mine `salt` so that `Clones.predictDeterministicAddress(implementation, salt, factory)` ends in `0x1110` (see [`salt-mining-guide.md`](../salt-mining-guide.md)). Statistically ~65k iterations.
 5. Submit `factory.createToken(name, symbol, salt, … same args …)` with `value: ethToSpend`.
 
@@ -108,7 +108,7 @@ In order, every successful call performs:
 4. **Initialize** the cloned token (mints `TOTAL_SUPPLY` to the launchpad, sets graduator/launchpad/feeHandler immutables, applies tax/anti-sniper configs).
 5. **`LAUNCHPAD.launchToken(token, BONDING_CURVE)`** — registers the token in the launchpad and emits `TokenLaunched`. The factory **must be whitelisted** on the launchpad or this reverts with `UnauthorizedFactory`.
 6. **`ILivoToken.registerFees(feeReceivers)`** — the token self-registers its fee config with `LivoMasterFeeHandler`. Emits one `DirectReceiverRegistered` per direct entry, then `SharesUpdated`.
-7. **If `msg.value > 0`**, the factory routes the ETH through `LAUNCHPAD.buyTokensWithExactEth` to buy supply, checks the aggregate buy doesn't exceed `maxBuyOnDeployBps`, and distributes the bought tokens proportionally across `supplyShares` (rounding dust goes to the last recipient). Emits `LivoTokenBuy` (launchpad) then `BuyOnDeploy` (factory).
+7. **If `msg.value > 0`**, the factory routes the ETH through `LAUNCHPAD.buyTokensWithExactEth` to buy supply (bounded only by graduation; a buy reaching the threshold graduates the token in the same tx) and distributes the bought tokens proportionally across `supplyShares` (rounding dust goes to the last recipient). Emits `LivoTokenBuy` (launchpad) then `BuyOnDeploy` (factory).
 
 Returns the deployed token address.
 
@@ -149,10 +149,9 @@ There is no upper bound on the array length at the factory layer. The master fee
 | Any duplicate `account` | `InvalidSupplyShares` |
 | Any `shares == 0` | `InvalidShares` |
 | `sum(shares) != 10_000` | `InvalidShares` |
-| Bought tokens exceed `maxBuyOnDeployBps` of `TOTAL_SUPPLY` (aggregate, not per recipient) | `InvalidBuyOnDeploy` |
-| Owner set `maxBuyOnDeployBps = 0` | `InvalidBuyOnDeploy` |
+| Deploy buy exceeds graduation (`graduationThreshold + maxExcessOverThreshold`) | `MaxEthReservesExceeded` |
 
-The cap is **aggregate**: splitting across N recipients does not bypass it. Default cap is `1_000` bps (10%) and is owner-mutable via `setMaxBuyOnDeployBps`.
+There is no buy-on-deploy cap: the deploy buy is bounded only by graduation. Use `maxBuyOnDeploy(liquidityTier, totalLockedInVaultsBps)` to size a buy up to the instant-graduation point.
 
 ### Anti-sniper config (`antiSniperCfg`)
 

--- a/src/config/manifest.ethereum.mainnet.sol
+++ b/src/config/manifest.ethereum.mainnet.sol
@@ -38,8 +38,8 @@ library DeploymentsEthereumMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x03AfF3484c04BeD2B2eA63b55475F03318eF7EA9;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x178A14654D080450e5Cf11b8f6114c6280Df7828;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x25A30503E2680CEDA6fa5b5d966Bc2219C37F464;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x81597b85f2C760d0960C84E4DAd8a5b4E9EeF0A5;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.ethereum.sepolia.sol
+++ b/src/config/manifest.ethereum.sepolia.sol
@@ -39,8 +39,8 @@ library DeploymentsEthereumSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x174a043E00C527e3D1a8e0bc19fE1E15e4e859f6;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x8ED7408Def91C96E7C76df3FA9B3a15918E5b1bd;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x2Fb8Bf5df18F215e22D9D91A82cE6D5Dd8121De3;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x17E8AD9f793b63C60725051eE4048928eCD2171F;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.robinhood.mainnet.sol
+++ b/src/config/manifest.robinhood.mainnet.sol
@@ -39,8 +39,8 @@ library DeploymentsRobinhoodMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x12947f43652BE26d7b418f0cEe3fE73259805222;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xDBfa01630382e88268df8AE00476e03eE2da1Af7;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xdA15442dCe5C2356C0b42d67DAc606C3dc2f4356;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xCBe739C13a031c446617f0722FDC081b9298979b;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.robinhood.testnet.sol
+++ b/src/config/manifest.robinhood.testnet.sol
@@ -39,8 +39,8 @@ library DeploymentsRobinhoodTestnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xEA528f484d5Af6ba0CDFcb569699CB7B9c9c5f38;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x014E675AA4ae0434b0840C177BAA454582aacF75;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x97BF1fC5Ee72Dd8c9686386ff00c99b6e3b9C00D;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xD8Ccee63514E8B0862f9E0fF82223b2DCa943936;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/factories/LivoFactoryAbstract.sol
+++ b/src/factories/LivoFactoryAbstract.sol
@@ -105,11 +105,6 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///         100 bps in LP fees, leaving 450 or 400 bps for tax.
     uint256 public constant MAX_TOTAL_FEE_BPS = 500;
 
-    /// @notice Max percentage of total supply that can be purchased on token creation (applies to the
-    ///         aggregate, not per recipient), in basis points. Fixed at 10%. To change this value,
-    ///         deploy a new implementation with a different constant and `upgradeTo` the proxy.
-    uint256 public constant maxBuyOnDeployBps = 1_000; // 10%
-
     /// @notice Total token supply minted per token. Mirrors `LivoToken.TOTAL_SUPPLY`; used to size
     ///         creator-vault allocations from their bps.
     uint256 internal constant TOTAL_SUPPLY = 1_000_000_000e18;
@@ -186,6 +181,23 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     /// @dev UUPS upgrade gate: only the owner can swap the implementation.
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
+    /// @notice Max tokens a deploy buy can purchase for a given liquidity tier and total creator-vault
+    ///         allocation. Buying this amount pushes the curve to exactly its graduation threshold, so the
+    ///         token graduates in the same `createToken` tx while staying clear of `maxExcessOverThreshold`
+    ///         — a deploy buy sized at or below it never reverts `MaxEthReservesExceeded`. There is no other
+    ///         cap on the deploy buy; graduation is the limit. Frontends read this to bound the deploy-buy
+    ///         token amount, then price it with `quoteBuyOnDeploy`.
+    /// @param totalLockedInVaultsBps Sum of `supplyBps` across the creator vaults (0 for none); selects the
+    ///        same curve `createToken` uses. Reverts `InvalidCreatorVault` if not a valid multiple in range.
+    function maxBuyOnDeploy(LiquidityTier tier, uint256 totalLockedInVaultsBps)
+        external
+        view
+        returns (uint256 maxTokens)
+    {
+        ILivoBondingCurve curve = _resolveBondingCurve(tier, totalLockedInVaultsBps);
+        (maxTokens,) = curve.buyTokensWithExactEth(0, curve.ethGraduationThreshold());
+    }
+
     ///////////////////////// INTERNAL FUNCTIONS /////////////////////////
 
     /// @dev Shared body for the concrete factories' `quoteBuyOnDeploy`: total ETH (including the
@@ -195,10 +207,11 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     ///      deployer will pass to `createToken` — the token doesn't exist at quote time, so the fee is
     ///      computed from those inputs rather than read from the token. Pass the SUM of `supplyBps`
     ///      across the vaults (0 for a non-vault token); only the aggregate matters (it keys the curve),
-    ///      so vault owners/vesting need not be finalized to quote. Doesn't account for the
-    ///      `maxBuyOnDeployBps` cap — the caller must keep `tokenAmount` under it. Reverts
-    ///      (`InvalidCreatorVault`) on a `totalLockedInVaultsBps` no vault array could sum to; a
-    ///      `buyFeeBps >= BASIS_POINTS` reverts on the subtraction below (nonsensical input).
+    ///      so vault owners/vesting need not be finalized to quote. The only bound on `tokenAmount` is
+    ///      graduation: keep it at or below `maxBuyOnDeploy(tier, totalLockedInVaultsBps)`, else the
+    ///      resulting buy reverts `MaxEthReservesExceeded`. Reverts (`InvalidCreatorVault`) on a
+    ///      `totalLockedInVaultsBps` no vault array could sum to; a `buyFeeBps >= BASIS_POINTS` reverts
+    ///      on the subtraction below (nonsensical input).
     function _quoteBuyOnDeploy(
         LiquidityTier tier,
         uint256 tokenAmount,
@@ -269,16 +282,14 @@ abstract contract LivoFactoryAbstract is ILivoFactory, Initializable, OwnableUpg
     }
 
     /// @dev Buys supply with `msg.value` and distributes it to `supplyShares` proportionally.
-    ///      The cap is enforced on the aggregate `tokensBought`, not per recipient. Rounding dust
-    ///      goes to the last recipient so no tokens remain in the factory.
+    ///      Rounding dust goes to the last recipient so no tokens remain in the factory. There is no
+    ///      per-deploy buy cap: the buy is bounded only by graduation — the launchpad/curve accept ETH
+    ///      up to `graduationThreshold + maxExcessOverThreshold` and revert `MaxEthReservesExceeded`
+    ///      beyond it (a buy that reaches the threshold graduates the token in this same tx). Use
+    ///      `maxBuyOnDeploy` to size a buy up to the instant-graduation point without risking that revert.
     /// @dev deployer-buy receivers bypass the sniper-protection features
     function _buyAndDistribute(address token, SupplyShare[] calldata supplyShares) internal {
         uint256 tokensBought = LAUNCHPAD.buyTokensWithExactEth{value: msg.value}(token, 0, block.timestamp);
-
-        // Floor division absorbs sub-token rounding from the bonding curve's ceiling math
-        require(
-            tokensBought * BASIS_POINTS / ILivoToken(token).totalSupply() <= maxBuyOnDeployBps, InvalidBuyOnDeploy()
-        );
 
         uint256 len = supplyShares.length;
         address[] memory recipients = new address[](len);

--- a/src/interfaces/ILivoFactory.sol
+++ b/src/interfaces/ILivoFactory.sol
@@ -131,7 +131,6 @@ interface ILivoFactory {
     error InvalidSupplyShares();
     error InvalidShares();
     error InvalidTokenAddress();
-    error InvalidBuyOnDeploy();
     error MultipleDirectFeeReceivers();
     error InvalidAntiSniperConfig();
     error InvalidTaxConfig();

--- a/test/e2e/suites/E2EHappyPath.t.sol
+++ b/test/e2e/suites/E2EHappyPath.t.sol
@@ -46,7 +46,7 @@ abstract contract E2EHappyPath is LivoE2EBase {
         ss[0] = ILivoFactory.SupplyShare({account: alice, shares: 7_000});
         ss[1] = ILivoFactory.SupplyShare({account: bob, shares: 3_000});
 
-        // 0.1 ether keeps the deployer buy under the factory's `maxBuyOnDeployBps` (10%).
+        // 0.1 ether keeps the deployer buy small (well below graduation).
         address token = _createTokenWithDeployerBuy(salt, 0.1 ether, ss);
 
         uint256 aliceAmt = IERC20(token).balanceOf(alice);

--- a/test/factories/FactoryUpgrade.t.sol
+++ b/test/factories/FactoryUpgrade.t.sol
@@ -78,18 +78,6 @@ contract FactoryUpgradeTests is LaunchpadBaseTestsWithUniv4Graduator {
         assertEq(address(factoryV4Unified.GRADUATOR()), newGraduator);
     }
 
-    function test_upgrade_preservesMaxBuyOnDeployBps() public {
-        // The constant ships at 1_000 (10%); upgrading to an impl built from the same code keeps it.
-        uint256 before = factoryV4Unified.maxBuyOnDeployBps();
-        assertEq(before, 1_000);
-
-        address newImpl = _deployV4ImplSameArgs();
-        vm.prank(admin);
-        factoryV4Unified.upgradeToAndCall(newImpl, "");
-
-        assertEq(factoryV4Unified.maxBuyOnDeployBps(), before);
-    }
-
     // ───────────── Upgrade authorization ─────────────
 
     function test_upgrade_revertsForNonOwner() public {

--- a/test/factories/LivoFactoryDeployerBuy.t.sol
+++ b/test/factories/LivoFactoryDeployerBuy.t.sol
@@ -11,6 +11,8 @@ import {LivoTaxableTokenUniV4} from "src/tokens/LivoTaxableTokenUniV4.sol";
 import {TokenState} from "src/types/tokenData.sol";
 import {ILivoFactory} from "src/interfaces/ILivoFactory.sol";
 import {ILivoToken} from "src/interfaces/ILivoToken.sol";
+import {ILivoBondingCurve} from "src/interfaces/ILivoBondingCurve.sol";
+import {TaxConfigs} from "src/interfaces/ILivoTaxableToken.sol";
 import {LivoLaunchpad} from "src/LivoLaunchpad.sol";
 import {LivoFactoryUniV4Unified} from "src/factories/LivoFactoryUniV4Unified.sol";
 
@@ -106,21 +108,6 @@ contract LivoFactoryUniV4DeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator
         assertEq(LivoToken(token).balanceOf(address(factoryV2)), 0);
     }
 
-    /// @dev cap applies to aggregate — a single recipient holding 100% shares can receive up to the full cap
-    function test_createToken_capAppliesToAggregate_singleRecipientCanHitFullCap() public {
-        uint256 maxTokens = TOTAL_SUPPLY * factoryV2.maxBuyOnDeployBps() / 10_000;
-        uint256 totalEthNeeded =
-            factoryV2.quoteBuyOnDeploy(LiquidityTier.DEFAULT, maxTokens, 0, _toCfgs(_emptyTaxCfg()));
-        bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
-
-        vm.prank(creator);
-        address token = factoryV2.createToken{value: totalEthNeeded}(
-            "TestToken", "TEST", salt, _fs(creator), _ss(creator), _emptyTaxCfg(), _emptyAntiSniperCfg()
-        );
-
-        assertGe(LivoToken(token).balanceOf(creator), maxTokens);
-    }
-
     // ============ Supply-share validation ============
 
     /// @dev shares not summing to 10 000 revert with InvalidShares
@@ -200,31 +187,18 @@ contract LivoFactoryUniV4DeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator
         );
     }
 
-    // ============ Cap Enforcement ============
+    // ============ Graduation ceiling ============
 
-    /// @dev reverts when ETH would buy more than the aggregate cap (10%)
-    function test_createToken_revertsWhenExceedingMaxBuy() public {
-        // 1 ether should buy way more than 10% at the start of the curve
+    /// @dev No buy-on-deploy cap: the deploy buy is bounded only by graduation. A buy whose ETH would push
+    ///      the curve past `graduationThreshold + maxExcessOverThreshold` reverts `MaxEthReservesExceeded`
+    ///      (DEFAULT threshold is 3.75 ETH, so 10 ETH is comfortably over the ceiling).
+    function test_createToken_revertsWhenBuyExceedsGraduationCeiling() public {
         bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
 
         vm.prank(creator);
-        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidBuyOnDeploy.selector));
-        factoryV2.createToken{value: 1 ether}(
+        vm.expectRevert(abi.encodeWithSelector(ILivoBondingCurve.MaxEthReservesExceeded.selector));
+        factoryV2.createToken{value: 10 ether}(
             "TestToken", "TEST", salt, _fs(creator), _ss(creator), _emptyTaxCfg(), _emptyAntiSniperCfg()
-        );
-    }
-
-    /// @dev cap is on aggregate — splitting doesn't bypass the cap
-    function test_createToken_revertsWhenAggregateExceedsCap_evenWithSplit() public {
-        bytes32 salt = _nextValidSalt(address(factoryV2), address(livoToken));
-        ILivoFactory.SupplyShare[] memory ss = new ILivoFactory.SupplyShare[](2);
-        ss[0] = ILivoFactory.SupplyShare({account: alice, shares: 5_000});
-        ss[1] = ILivoFactory.SupplyShare({account: bob, shares: 5_000});
-
-        vm.prank(creator);
-        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidBuyOnDeploy.selector));
-        factoryV2.createToken{value: 1 ether}(
-            "TestToken", "TEST", salt, _fs(creator), ss, _emptyTaxCfg(), _emptyAntiSniperCfg()
         );
     }
 
@@ -263,9 +237,10 @@ contract LivoFactoryUniV4DeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator
         assertApproxEqRel(creatorBalance, tokenAmount, 0.005e18); // quote is tight: deployer doesn't materially overpay
     }
 
-    /// @dev quoteBuyOnDeploy at max allowed tokens does not revert on createToken
-    function test_quoteBuyOnDeploy_maxAllowedTokens_doesNotRevert() public {
-        uint256 maxTokens = TOTAL_SUPPLY * factoryV2.maxBuyOnDeployBps() / 10_000;
+    /// @dev At `maxBuyOnDeploy` the deploy buy reaches the graduation threshold: createToken succeeds
+    ///      (no MaxEthReservesExceeded) and the token graduates in the same tx.
+    function test_maxBuyOnDeploy_reachesGraduation() public {
+        uint256 maxTokens = factoryV2.maxBuyOnDeploy(LiquidityTier.DEFAULT, 0);
         uint256 totalEthNeeded =
             factoryV2.quoteBuyOnDeploy(LiquidityTier.DEFAULT, maxTokens, 0, _toCfgs(_emptyTaxCfg()));
 
@@ -277,6 +252,7 @@ contract LivoFactoryUniV4DeployerBuyTest is LaunchpadBaseTestsWithUniv2Graduator
         );
 
         assertGe(LivoToken(token).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy must graduate the token");
     }
 
     /// @dev With a graduation-anchored tax window (`startTaxFromLaunch == false`) the deploy buy pays
@@ -360,15 +336,16 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
         assertEq(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), 0);
     }
 
-    // ============ Cap Enforcement ============
+    // ============ Graduation ceiling ============
 
-    /// @dev reverts when ETH would buy more than 10% of supply
-    function test_createToken_revertsWhenExceedingMaxBuy() public {
+    /// @dev No buy-on-deploy cap: a deploy buy past `graduationThreshold + maxExcessOverThreshold`
+    ///      reverts `MaxEthReservesExceeded` (DEFAULT threshold 3.75 ETH; 10 ETH is over the ceiling).
+    function test_createToken_revertsWhenBuyExceedsGraduationCeiling() public {
         bytes32 salt = _nextValidSalt(address(factoryTax), address(livoTaxToken));
 
         vm.prank(creator);
-        vm.expectRevert(abi.encodeWithSelector(ILivoFactory.InvalidBuyOnDeploy.selector));
-        factoryTax.createToken{value: 1 ether}(
+        vm.expectRevert(abi.encodeWithSelector(ILivoBondingCurve.MaxEthReservesExceeded.selector));
+        factoryTax.createToken{value: 10 ether}(
             "TestToken",
             "TEST",
             salt,
@@ -467,9 +444,10 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
         assertApproxEqRel(creatorBalance, tokenAmount, 0.005e18); // quote is tight: deployer doesn't materially overpay
     }
 
-    /// @dev quoteBuyOnDeploy at max allowed tokens does not revert on createToken
-    function test_quoteBuyOnDeploy_maxAllowedTokens_doesNotRevert() public {
-        uint256 maxTokens = TOTAL_SUPPLY * factoryTax.maxBuyOnDeployBps() / 10_000;
+    /// @dev At `maxBuyOnDeploy` the tax-token deploy buy reaches graduation: createToken succeeds and the
+    ///      token graduates in the same tx.
+    function test_maxBuyOnDeploy_reachesGraduation() public {
+        uint256 maxTokens = factoryTax.maxBuyOnDeploy(LiquidityTier.DEFAULT, 0);
         uint256 totalEthNeeded = factoryTax.quoteBuyOnDeploy(
             LiquidityTier.DEFAULT, maxTokens, 0, _toCfgs(_taxCfg(0, 400, uint32(14 days))), _univ4Cfg100()
         );
@@ -489,6 +467,115 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
         );
 
         assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy must graduate the token");
+    }
+
+    /// @dev `maxBuyOnDeploy` is a TOKEN amount, independent of fees/taxes (the curve reserve ceiling is on
+    ///      post-fee reserves). So a token launching with a BUY tax active from launch still graduates on a
+    ///      max deploy buy: the deploy buy pays LP fee + launch buy tax, but `quoteBuyOnDeploy` grosses the
+    ///      ETH up for both, so reserves still land at the graduation threshold. 4% buy tax (+1% V4 LP fee).
+    function test_maxBuyOnDeploy_reachesGraduation_withLaunchBuyTax() public {
+        uint256 maxTokens = factoryTax.maxBuyOnDeploy(LiquidityTier.DEFAULT, 0);
+        uint256 totalEthNeeded = factoryTax.quoteBuyOnDeploy(
+            LiquidityTier.DEFAULT, maxTokens, 0, _toCfgs(_taxCfg(400, 0, uint32(14 days))), _univ4Cfg100()
+        );
+
+        bytes32 salt = _nextValidSalt(address(factoryTax), address(livoTaxToken));
+
+        vm.prank(creator);
+        address token = factoryTax.createToken{value: totalEthNeeded}(
+            "TestToken",
+            "TEST",
+            salt,
+            _fs(creator),
+            _ss(creator),
+            false,
+            _taxCfg(400, 0, uint32(14 days)), // buyTax 400, startTaxFromLaunch defaults true
+            _emptyAntiSniperCfg()
+        );
+
+        assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy with launch buy tax must graduate");
+    }
+
+    /// @dev Same, with a launch-anchored decaying buy tax (decay-only token): at elapsed≈0 the deploy buy
+    ///      pays the full 10% decay-start buy rate (+1% LP), and the max deploy buy still graduates because
+    ///      `quoteBuyOnDeploy` grosses the ETH up for the decay-start rate.
+    function test_maxBuyOnDeploy_reachesGraduation_withLaunchDecayBuyTax() public {
+        uint256 maxTokens = factoryTax.maxBuyOnDeploy(LiquidityTier.DEFAULT, 0);
+        uint256 totalEthNeeded = factoryTax.quoteBuyOnDeploy(
+            LiquidityTier.DEFAULT, maxTokens, 0, _decayCfg(1000, 0, 20 minutes, true), _univ4Cfg100()
+        );
+
+        bytes32 salt = _nextValidSalt(address(factoryTax), address(livoTaxToken));
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "TestToken", symbol: "TEST", salt: salt, feeShares: _fs(creator), liquidityTier: LiquidityTier.DEFAULT
+        });
+
+        vm.prank(creator);
+        address token = factoryTax.createToken{value: totalEthNeeded}(
+            setup,
+            _decayCfg(1000, 0, 20 minutes, true),
+            _univ4Cfg100(),
+            _ss(creator),
+            _emptyAntiSniperCfg(),
+            new ILivoFactory.CreatorVault[](0),
+            address(0)
+        );
+
+        assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy with launch decay buy tax must graduate");
+    }
+
+    /// @dev Tightest deploy-buy: max creator vault (30%) locked + a launch-anchored BUY tax. `maxBuyOnDeploy`
+    ///      reads the 30%-vault curve (a smaller float) and `quoteBuyOnDeploy` grosses the ETH up for LP +
+    ///      launch buy tax — the max deploy buy still graduates in the same tx with no revert. 4% buy tax.
+    function test_maxBuyOnDeploy_reachesGraduation_withMaxVaultAndLaunchBuyTax() public {
+        uint256 vaultBps = 3000; // 30% max
+        uint256 maxTokens = factoryTax.maxBuyOnDeploy(LiquidityTier.DEFAULT, vaultBps);
+        TaxConfigs memory taxConfigs = _toCfgs(_taxCfg(400, 0, uint32(14 days)));
+        uint256 totalEthNeeded =
+            factoryTax.quoteBuyOnDeploy(LiquidityTier.DEFAULT, maxTokens, vaultBps, taxConfigs, _univ4Cfg100());
+
+        address token = _createMaxVaultTaxToken(vaultBps, taxConfigs, totalEthNeeded);
+
+        assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy w/ 30% vault + launch buy tax must graduate");
+    }
+
+    /// @dev Same tightest scenario with a launch-anchored decaying buy tax (10% decay start).
+    function test_maxBuyOnDeploy_reachesGraduation_withMaxVaultAndLaunchDecayTax() public {
+        uint256 vaultBps = 3000; // 30% max
+        uint256 maxTokens = factoryTax.maxBuyOnDeploy(LiquidityTier.DEFAULT, vaultBps);
+        TaxConfigs memory taxConfigs = _decayCfg(1000, 0, 20 minutes, true);
+        uint256 totalEthNeeded =
+            factoryTax.quoteBuyOnDeploy(LiquidityTier.DEFAULT, maxTokens, vaultBps, taxConfigs, _univ4Cfg100());
+
+        address token = _createMaxVaultTaxToken(vaultBps, taxConfigs, totalEthNeeded);
+
+        assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
+        assertTrue(launchpad.getTokenState(token).graduated, "max buy w/ 30% vault + launch decay tax must graduate");
+    }
+
+    /// @dev Deploys a DEFAULT-tier tax token with a single 30%-vault, funding the deployer buy with `value`.
+    function _createMaxVaultTaxToken(uint256 vaultBps, TaxConfigs memory taxConfigs, uint256 value)
+        internal
+        returns (address token)
+    {
+        ILivoFactory.CreatorVault[] memory vaults = new ILivoFactory.CreatorVault[](1);
+        vaults[0] = ILivoFactory.CreatorVault({owner: creator, supplyBps: vaultBps, cliffSeconds: 0, vestingSeconds: 1});
+        ILivoFactory.TokenSetupTiered memory setup = ILivoFactory.TokenSetupTiered({
+            name: "TestToken",
+            symbol: "TEST",
+            salt: _nextValidSalt(address(factoryTax), address(livoTaxToken)),
+            feeShares: _fs(creator),
+            liquidityTier: LiquidityTier.DEFAULT
+        });
+
+        vm.prank(creator);
+        token = factoryTax.createToken{value: value}(
+            setup, taxConfigs, _univ4Cfg100(), _ss(creator), _emptyAntiSniperCfg(), vaults, address(0)
+        );
     }
 
     /// @dev With a graduation-anchored tax window (`startTaxFromLaunch == false`) the deploy buy pays
@@ -519,32 +606,5 @@ contract LivoFactoryTaxTokenDeployerBuyTest is LaunchpadBaseTestsWithUniv4Gradua
         uint256 creatorBalance = LivoTaxableTokenUniV4(payable(token)).balanceOf(creator);
         assertGe(creatorBalance, tokenAmount);
         assertApproxEqRel(creatorBalance, tokenAmount, 0.005e18); // within 0.5% of the quote
-    }
-
-    /// @dev The user-facing harm of an inflated quote: at the `maxBuyOnDeployBps` limit, the extra
-    ///      ETH from wrongly including a graduation-anchored `buyTaxBps` buys more than the cap and
-    ///      `createToken` reverts with InvalidBuyOnDeploy.
-    function test_quoteBuyOnDeploy_graduationAnchoredTax_maxAllowedTokens_doesNotRevert() public {
-        uint256 maxTokens = TOTAL_SUPPLY * factoryTax.maxBuyOnDeployBps() / 10_000;
-        uint16 buyTax = 400;
-        uint256 totalEthNeeded = factoryTax.quoteBuyOnDeploy(
-            LiquidityTier.DEFAULT, maxTokens, 0, _toCfgs(_taxCfg(buyTax, 0, uint32(14 days), false)), _univ4Cfg100()
-        );
-
-        bytes32 salt = _nextValidSalt(address(factoryTax), address(livoTaxToken));
-
-        vm.prank(creator);
-        address token = factoryTax.createToken{value: totalEthNeeded}(
-            "TestToken",
-            "TEST",
-            salt,
-            _fs(creator),
-            _ss(creator),
-            false,
-            _taxCfg(buyTax, 0, uint32(14 days), false),
-            _emptyAntiSniperCfg()
-        );
-
-        assertGe(LivoTaxableTokenUniV4(payable(token)).balanceOf(creator), maxTokens);
     }
 }

--- a/test/factories/LivoFactoryDirectFees.t.sol
+++ b/test/factories/LivoFactoryDirectFees.t.sol
@@ -90,7 +90,7 @@ contract LivoFactoryDirectFeesTest is LaunchpadBaseTestsWithUniv4Graduator {
 
         bytes32 salt = _nextValidSalt(address(factoryV4Unified), address(livoToken));
         vm.deal(creator, 5 ether);
-        // Small buy to stay under maxBuyOnDeployBps; the trace shows registration is invoked
+        // Small buy so the token stays pre-graduation; the trace shows registration is invoked
         // immediately after token init, before any fee can possibly flow.
         vm.prank(creator);
         address token = factoryV4Unified.createToken{value: 0.05 ether}(

--- a/test/graduators/tierLiquidityMatrix.t.sol
+++ b/test/graduators/tierLiquidityMatrix.t.sol
@@ -147,6 +147,25 @@ contract TierLiquidityMatrixTest is LaunchpadBaseTestsWithUniv4Graduator {
         }
     }
 
+    /// @dev Scenario 3: a creator buy sized at `maxBuyOnDeploy` (the entire pre-graduation float) is
+    ///      accepted for every vault level and graduates the token inside the same `createToken` tx — the
+    ///      max buy reaches the graduation threshold without tripping `MaxEthReservesExceeded`. Proves the
+    ///      no-cap deploy buy is bounded only by graduation, across tiers and up to the 30% max vault.
+    function _sweepCreatorBuyMax(LiquidityTier tier) internal {
+        for (uint256 j; j < BPS_IDX.length; ++j) {
+            uint256 i = BPS_IDX[j];
+            string memory ctx = _ctx(tier, BPS[i]);
+            uint256 maxTokens = factoryV4Unified.maxBuyOnDeploy(tier, BPS[i]);
+            uint256 ethNeeded =
+                factoryV4Unified.quoteBuyOnDeploy(tier, maxTokens, BPS[i], _toCfgs(_emptyTaxCfg()), _cfg());
+            address token = _create(tier, BPS[i], ethNeeded, _ss(creator));
+            assertTrue(
+                launchpad.getTokenState(token).graduated, string.concat(ctx, "max creator buy must graduate the token")
+            );
+            assertGe(ILivoToken(token).balanceOf(creator), maxTokens, string.concat(ctx, "deployer got less than max"));
+        }
+    }
+
     /// @dev Scenarios 4/5: a normal launchpad buy returns tokens; selling them all back returns eth that
     ///      matches the launchpad quote and never exceeds the eth deposited. Stays well below the lowest
     ///      tier threshold (THIN = 2.0 ETH) so the token does not graduate mid-test.
@@ -229,23 +248,20 @@ contract TierLiquidityMatrixTest is LaunchpadBaseTestsWithUniv4Graduator {
         _sweepCreatorBuy(LiquidityTier.THICK, TOTAL_SUPPLY / 100);
     }
 
-    // ───────────────────────── scenario 3: create + creator buy (max quoted) ─────────────────────────
-    // The buy-on-deploy cap: maxBuyOnDeployBps (10%) of supply.
-
-    function _maxBuyTokens() internal view returns (uint256) {
-        return TOTAL_SUPPLY * factoryV4Unified.maxBuyOnDeployBps() / 10_000;
-    }
+    // ───────────────────────── scenario 3: create + creator buy (max = up to graduation) ─────────────────────────
+    // No buy-on-deploy cap: the max is `maxBuyOnDeploy` (the whole pre-graduation float), and buying it
+    // graduates the token in the same createToken tx.
 
     function test_creatorBuyMax_thin() public {
-        _sweepCreatorBuy(LiquidityTier.THIN, _maxBuyTokens());
+        _sweepCreatorBuyMax(LiquidityTier.THIN);
     }
 
     function test_creatorBuyMax_default() public {
-        _sweepCreatorBuy(LiquidityTier.DEFAULT, _maxBuyTokens());
+        _sweepCreatorBuyMax(LiquidityTier.DEFAULT);
     }
 
     function test_creatorBuyMax_thick() public {
-        _sweepCreatorBuy(LiquidityTier.THICK, _maxBuyTokens());
+        _sweepCreatorBuyMax(LiquidityTier.THICK);
     }
 
     // ───────────────────────── scenarios 4/5: buy + sell from launchpad ─────────────────────────

--- a/test/integration/fork/base/ForkIntegrationBase.t.sol
+++ b/test/integration/fork/base/ForkIntegrationBase.t.sol
@@ -487,9 +487,7 @@ abstract contract ForkIntegrationBase is ForkIntegrationConfig {
             return;
         }
 
-        uint256 maxBuyOnDeployBps = _isV4(c) ? factoryV4.maxBuyOnDeployBps() : factoryV2.maxBuyOnDeployBps();
         assertGt(releasedSupply, 0, "missing deployer-buy released supply");
-        assertLe(releasedSupply, TOTAL_SUPPLY * maxBuyOnDeployBps / 10_000, "deployer buy cap");
 
         if (c.creatorBuyMode == ForkIntegrationCaseLib.CreatorBuyMode.SingleSupplyReceiver) {
             assertEq(creatorBal, releasedSupply, "single supply receiver mismatch");

--- a/test/tokens/sniperProtection.t.sol
+++ b/test/tokens/sniperProtection.t.sol
@@ -283,9 +283,9 @@ abstract contract SniperProtectionBaseTest is Test {
         assertEq(_token().balanceOf(buyer2), MAX_WALLET);
     }
 
-    /// Deployer-buy path: launchpad → factory → supplyShares. The launchpad → factory hop moves
-    /// up to 10% of supply (factory's `maxBuyOnDeployBps`), which is far above the 3% cap. The
-    /// recipient-is-factory exemption lets this pass.
+    /// Deployer-buy path: launchpad → factory → supplyShares. The launchpad → factory hop can move a
+    /// large share of supply (the deploy buy is uncapped, bounded only by graduation) — here 10%, far
+    /// above the 3% cap. The recipient-is-factory exemption lets this pass.
     /// @dev `tokenFactory` lives in transient storage on the token, so the recipient-is-factory
     ///      exemption only fires while init and the deployer-buy hop run in the same tx — which
     ///      mirrors the production flow (the factory's `createToken` does both atomically). We


### PR DESCRIPTION
## What & why

Removes the 10% cap on the creator/deploy buy. Per the new requirement, the deploy buy is bounded only by **graduation**.

There is no vault/buy conflict: creator vaults are carved from supply **before** the curve, so the deploy buy competes only with the free float, never the vault or the liquidity floor. The buckets always sum to 1B — `vault + T_GRAD(≈285.7M, constant per tier) + buyable` — so the max buyable is `71.43% − vaultBps%` of supply (≥ 41.43% even at the 30% max vault).

## Changes

- **`LivoFactoryAbstract`**: drop the `maxBuyOnDeployBps` cap check in `_buyAndDistribute` and the constant. The deploy buy is now limited by the curve's existing graduation ceiling — a buy past `graduationThreshold + maxExcessOverThreshold` reverts `MaxEthReservesExceeded`; a buy reaching the threshold **graduates the token in the same `createToken` tx** (a desired feature).
- Add `maxBuyOnDeploy(LiquidityTier tier, uint256 totalLockedInVaultsBps)` → the token amount that lands the curve at exactly the graduation threshold. It is **fee/tax-independent** (the reserve ceiling is on post-fee reserves); size the buy with it, then price with `quoteBuyOnDeploy(tokenAmount, taxCfg)` which grosses the ETH up for LP fee + launch buy tax.
- **`ILivoFactory`**: remove the now-unused `InvalidBuyOnDeploy` error.
- Update integration docs.

## Tests

All buy `maxBuyOnDeploy(...)`, price via `quoteBuyOnDeploy(...)`, `createToken`, and assert the token graduated (so any revert or non-graduation fails):

- `tierLiquidityMatrix::test_creatorBuyMax_{thin,default,thick}` — max buy graduates across all 3 tiers × {5%, 30% vault}.
- `LivoFactoryDeployerBuy`: graduation on max buy (V2 + V4 tax); over-ceiling reverts `MaxEthReservesExceeded`; **launch buy tax** (static 4% + decaying 10%); **30% vault + launch tax** (static + decay).

Removed obsolete cap tests; fixed stale docs/comments.

## Verification

`just fast-test` green (1143 passed / 0 failed); the `maxBuyOnDeploy_reachesGraduation*` family + tier sweeps all pass. `forge fmt` clean.

## Upgrade note (ABI)

`maxBuyOnDeployBps()` getter and the `InvalidBuyOnDeploy` error are removed; frontends/integrators must switch to `maxBuyOnDeploy(tier, totalLockedInVaultsBps)`. No storage-layout or constructor-arg changes — deployable as a new impl + `upgradeTo` on the existing proxies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
