### PR TITLE
feat(sniper): raise anti-sniper whitelist cap from 20 to 50

### DIFF
--- a/deployments.ethereum.mainnet.md
+++ b/deployments.ethereum.mainnet.md
@@ -15,13 +15,13 @@
 | LivoLpFeeRouter (proxy)                      | `0xe229557449f65e20368c40B3fb7471CB50dcB3eA` |
 | LivoLpFeeRouter (impl)                       | `0xbbA67f3f1D2D1C17328eD9B02251b1b7Dc762E6C` |
 | LivoQuoter                                   | `0xBd208C238Dd7895a7b94833063C2397F10E056f1` |
-| LivoToken (impl)                             | `0x94D150d4FBd8e3206Ad5b9882382Ad045e54a0f1` |
-| LivoTaxableTokenUniV4 (impl)                 | `0x11f00757Fe8D9a3cC71181232107D26e87e6e61F` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x57a62Ad2E67D02a5b3c78cbC0F979f7aE75446A6` |
+| LivoToken (impl)                             | `0xf8CAD09f010f4ADFFCa63D049860469D5f3c6eAA` |
+| LivoTaxableTokenUniV4 (impl)                 | `0xfe09d129C227682849cF80d6a016A1022401289D` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x12a1FD4677F5985F4624FD44Ce44d9adE2833839` |
 | LivoFactoryUniV2Unified (proxy)              | `0x78Af7E41ab894fc2aCd1b1c918e3CC6d710054b9` |
-| LivoFactoryUniV2Unified (impl)               | `0x33033F027f953458301143654c124AC7aE990228` |
+| LivoFactoryUniV2Unified (impl)               | `0x24cd5AB9f3cebF9f332DD1A326EFB4EeB71441EE` |
 | LivoFactoryUniV4Unified (proxy)              | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
-| LivoFactoryUniV4Unified (impl)               | `0xe507D3Fa961b178fB9e4f445dE7BD75F42C99289` |
+| LivoFactoryUniV4Unified (impl)               | `0x61644515be886c211A4A0dAf8588165305d85be7` |
 | LivoCreatorVaultFactory (proxy)              | `0xA06f07bf255cB63c694339F172f9459f3BF015E7` |
 | LivoCreatorVaultFactory (impl)               | `0x4b387716EbA7498Eb757467A876FAA98733A329e` |
 | LivoCreatorVault (impl)                      | `0xcad4C889e0897BF3fdeE367F402F728342651603` |

--- a/deployments.ethereum.sepolia.md
+++ b/deployments.ethereum.sepolia.md
@@ -15,13 +15,13 @@
 | LivoLpFeeRouter (proxy)                      | `0x0cEC114e1b8712EBd9d67a773381410F0F78985A` |
 | LivoLpFeeRouter (impl)                       | `0x215a7Cf7Cb881f52CA5350032ae56d27018A5889` |
 | LivoQuoter                                   | `0x17b8f037a261344714A64643Bde0Bd7C5745b3BE` |
-| LivoToken (impl)                             | `0xaa4331d36F360DCed845541348A33e64e6F9619c` |
-| LivoTaxableTokenUniV4 (impl)                 | `0x202fA5672BA4840c08dd2aAD66C41937D86f2128` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x0152D42953E8aCC7d1Ad941E7761615040DB04FC` |
+| LivoToken (impl)                             | `0x171d6448db236Ca3e185e0c9536f0B4D26C1cc24` |
+| LivoTaxableTokenUniV4 (impl)                 | `0xCCAf520224f6334dE8911B20E78B6Fa1df6D75cb` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x89b299A94B6d8Cb1B9F539a1B9B7a2CDd027DFE4` |
 | LivoFactoryUniV2Unified (proxy)              | `0x87Dd69F8d294fA9cd704fccd38d36d6197F80868` |
-| LivoFactoryUniV2Unified (impl)               | `0xE73fE61298C5069137BD425BA9305EabDc476fa2` |
+| LivoFactoryUniV2Unified (impl)               | `0xe2d96367A020B2a04465959B62d985E16bc11764` |
 | LivoFactoryUniV4Unified (proxy)              | `0x2a992f6f5F7c049A165a13069BE3DbDEaa5C391b` |
-| LivoFactoryUniV4Unified (impl)               | `0xa405E52A21ed5CA5401A51264d071F2E995D6772` |
+| LivoFactoryUniV4Unified (impl)               | `0x12bEbC0FAeE410F502674e00eaF27ada66b1172F` |
 | LivoCreatorVaultFactory (proxy)              | `0x804ad45394FCF755350d924f712EC463E5E3147D` |
 | LivoCreatorVaultFactory (impl)               | `0xcbeBF86091de0E2c5d18D6c4E3d44e44855C2C47` |
 | LivoCreatorVault (impl)                      | `0xe5aF8d840963060302cf5021630d6dBF41a9e07b` |

--- a/deployments.robinhood.mainnet.md
+++ b/deployments.robinhood.mainnet.md
@@ -15,13 +15,13 @@
 | LivoLpFeeRouter (proxy)                      | `0x3175bB69cfeE26FC90ea0A33E45BbDe466053f43` |
 | LivoLpFeeRouter (impl)                       | `0x3C6773BC3e9dBC76834e3F38D05066BA72Abd410` |
 | LivoQuoter                                   | `0x5176076dD27C12b5fF60eFbf97D2C6a0697CE0DF` |
-| LivoToken (impl)                             | `0x32B4F048d15178FA1958BA6eC3ac8007d516E5e9` |
-| LivoTaxableTokenUniV4 (impl)                 | `0x2f1C9cf234E17ca0Df9A8071c83D8794B3be2058` |
-| LivoTaxableTokenUniV2 (impl)                 | `0x50e30bfE4CFB0b6aC6369eE54D7510B2473573fF` |
+| LivoToken (impl)                             | `0x92A71B6A578D2345946DeCeDbCA3874702a3fCa3` |
+| LivoTaxableTokenUniV4 (impl)                 | `0xCbcaB7c9d9Ce45CEFb17bBEbd419881b253d7371` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x2Bf62383a4A1349461bB744b4eC561338D8b4CF9` |
 | LivoFactoryUniV2Unified (proxy)              | `0x7843203be233b3Be7E5017A68a64FdBf32b45fFE` |
-| LivoFactoryUniV2Unified (impl)               | `0x209504c3fB153a2e37690c30441eC67e909FE490` |
+| LivoFactoryUniV2Unified (impl)               | `0x66534bDE4f69F69342F929479797F7118B7ca74F` |
 | LivoFactoryUniV4Unified (proxy)              | `0xb637800Dcd5c83913D828E961dBB964A9896f19d` |
-| LivoFactoryUniV4Unified (impl)               | `0x17d5e0776dafa4CAE8e6e1eBbf7278e1c4AF647f` |
+| LivoFactoryUniV4Unified (impl)               | `0xF74aD241bDe9e2DAe7849D06ee4935731c1B5258` |
 | LivoCreatorVaultFactory (proxy)              | `0xBa1a7Fe65E7aAb563630F5921080996030a80AA1` |
 | LivoCreatorVaultFactory (impl)               | `0xf5E30BE2b72b0dEbCD85103AdaE399CbC3046Fcf` |
 | LivoCreatorVault (impl)                      | `0xE735d281d313AD09bd8bFF81F181715b6c6aD772` |

--- a/deployments.robinhood.testnet.md
+++ b/deployments.robinhood.testnet.md
@@ -15,13 +15,13 @@
 | LivoLpFeeRouter (proxy)                      | `0x9A996216c0Cd3B1cDeDC4D2A38E0ca94eBeC3565` |
 | LivoLpFeeRouter (impl)                       | `0x75A42715c6B8912631971c0737E523a662Ec7064` |
 | LivoQuoter                                   | `0xaA9c5758D8E5804dbbC4c931C6EAf1Be68DD30CD` |
-| LivoToken (impl)                             | `0x4B85Bd6406BE504832De9DeDe12ede7f08a72869` |
-| LivoTaxableTokenUniV4 (impl)                 | `0x6382Aa066577Ff125CF67711aE859f351af1FFff` |
-| LivoTaxableTokenUniV2 (impl)                 | `0xcB5d351D5e418e832DB4F1d23E1D553C0DB643Ee` |
+| LivoToken (impl)                             | `0xf68Ea9a3522647C58d7c77edE156cAA0930a7101` |
+| LivoTaxableTokenUniV4 (impl)                 | `0x2aAE5BAa1FFE5a93a0feE92cb1d73FDA80120728` |
+| LivoTaxableTokenUniV2 (impl)                 | `0x1f4F57DdCda5f2697899eEBe763682279b7aE39a` |
 | LivoFactoryUniV2Unified (proxy)              | `0xc0dE7109626A458dE1E0Ff06106830beD96DE971` |
-| LivoFactoryUniV2Unified (impl)               | `0x48b3F72469cDba3986A36cE6C47e6Cb027dCCcF2` |
+| LivoFactoryUniV2Unified (impl)               | `0xBB0EBb375e9dc06DE3eC0d6410606Cb3DAc6737b` |
 | LivoFactoryUniV4Unified (proxy)              | `0xfBa7137768E53f3B6a0d2333F41C44BaC7161FA0` |
-| LivoFactoryUniV4Unified (impl)               | `0x974F9139D56DAE3D44714Cd24632BB9Bf69139E2` |
+| LivoFactoryUniV4Unified (impl)               | `0x23f1b9158071B651268c4A626808958E2DC63f02` |
 | LivoCreatorVaultFactory (proxy)              | `0x7BA7523E87a07514Ec059D233AefbDED0C21833B` |
 | LivoCreatorVaultFactory (impl)               | `0x76f404dDcbc6E3ff466F983121CC2b0D8a63F4cb` |
 | LivoCreatorVault (impl)                      | `0xd1B50918Aa2e34b89A89B23C84d2377F1622d0f6` |

--- a/docs/create-token-recommended-overload.md
+++ b/docs/create-token-recommended-overload.md
@@ -168,7 +168,7 @@ All errors are 4-byte custom errors.
 | `MaxWalletBpsTooLow` / `…TooHigh` | (window enabled) `maxWalletBps` outside `10..300`. |
 | `MaxBuyPerTxBpsExceedsMaxWalletBps` | (window enabled) `maxBuyPerTxBps > maxWalletBps`. |
 | `ProtectionWindowTooShort` / `…TooLong` | (window enabled) `protectionWindowSeconds` outside `60..86_400`. |
-| `WhitelistTooLong` | `whitelist.length > 20`. |
+| `WhitelistTooLong` | `whitelist.length > 50`. |
 | `InvalidCreatorVault` | a vault `owner == address(0)`, or `supplyBps` is zero / not a multiple of 500. |
 | `CreatorVaultAllocationTooHigh` | sum of `supplyBps` > `3_000` (30%). |
 | `TooManyCreatorVaults` | more than 5 vaults. |

--- a/docs/external/factory-createToken-integration.md
+++ b/docs/external/factory-createToken-integration.md
@@ -172,7 +172,7 @@ Once `protectionWindowSeconds > 0`, the **token's** initializer enforces the sub
 | `maxBuyPerTxBps > maxWalletBps` | `MaxBuyPerTxBpsExceedsMaxWalletBps` |
 | `protectionWindowSeconds < 60` | `ProtectionWindowTooShort` |
 | `protectionWindowSeconds > 86_400` | `ProtectionWindowTooLong` |
-| `whitelist.length > 20` | `WhitelistTooLong` |
+| `whitelist.length > 50` | `WhitelistTooLong` |
 
 ### Tax config (`taxCfg`)
 

--- a/src/config/manifest.ethereum.mainnet.sol
+++ b/src/config/manifest.ethereum.mainnet.sol
@@ -24,11 +24,11 @@ library DeploymentsEthereumMainnet {
     address internal constant QUOTER = 0xBd208C238Dd7895a7b94833063C2397F10E056f1;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0x94D150d4FBd8e3206Ad5b9882382Ad045e54a0f1;
-    address internal constant TAXABLE_TOKEN_V4_IMPL = 0x11f00757Fe8D9a3cC71181232107D26e87e6e61F;
+    address internal constant TOKEN_IMPL = 0xf8CAD09f010f4ADFFCa63D049860469D5f3c6eAA;
+    address internal constant TAXABLE_TOKEN_V4_IMPL = 0xfe09d129C227682849cF80d6a016A1022401289D;
 
     /// @notice V2 taxable token implementation (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x57a62Ad2E67D02a5b3c78cbC0F979f7aE75446A6;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x12a1FD4677F5985F4624FD44Ce44d9adE2833839;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -38,8 +38,8 @@ library DeploymentsEthereumMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x33033F027f953458301143654c124AC7aE990228;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xe507D3Fa961b178fB9e4f445dE7BD75F42C99289;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x24cd5AB9f3cebF9f332DD1A326EFB4EeB71441EE;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x61644515be886c211A4A0dAf8588165305d85be7;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.ethereum.sepolia.sol
+++ b/src/config/manifest.ethereum.sepolia.sol
@@ -25,11 +25,11 @@ library DeploymentsEthereumSepolia {
     address internal constant QUOTER = 0x17b8f037a261344714A64643Bde0Bd7C5745b3BE;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0xaa4331d36F360DCed845541348A33e64e6F9619c;
-    address internal constant TAXABLE_TOKEN_V4_IMPL = 0x202fA5672BA4840c08dd2aAD66C41937D86f2128;
+    address internal constant TOKEN_IMPL = 0x171d6448db236Ca3e185e0c9536f0B4D26C1cc24;
+    address internal constant TAXABLE_TOKEN_V4_IMPL = 0xCCAf520224f6334dE8911B20E78B6Fa1df6D75cb;
 
     /// @notice V2 taxable token implementation (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x0152D42953E8aCC7d1Ad941E7761615040DB04FC;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x89b299A94B6d8Cb1B9F539a1B9B7a2CDd027DFE4;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -39,8 +39,8 @@ library DeploymentsEthereumSepolia {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xE73fE61298C5069137BD425BA9305EabDc476fa2;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xa405E52A21ed5CA5401A51264d071F2E995D6772;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xe2d96367A020B2a04465959B62d985E16bc11764;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x12bEbC0FAeE410F502674e00eaF27ada66b1172F;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.robinhood.mainnet.sol
+++ b/src/config/manifest.robinhood.mainnet.sol
@@ -32,11 +32,11 @@ library DeploymentsRobinhoodMainnet {
     address internal constant QUOTER = 0x5176076dD27C12b5fF60eFbf97D2C6a0697CE0DF;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0x32B4F048d15178FA1958BA6eC3ac8007d516E5e9;
-    address internal constant TAXABLE_TOKEN_V4_IMPL = 0x2f1C9cf234E17ca0Df9A8071c83D8794B3be2058;
+    address internal constant TOKEN_IMPL = 0x92A71B6A578D2345946DeCeDbCA3874702a3fCa3;
+    address internal constant TAXABLE_TOKEN_V4_IMPL = 0xCbcaB7c9d9Ce45CEFb17bBEbd419881b253d7371;
 
     /// @notice V2 taxable token implementation (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x50e30bfE4CFB0b6aC6369eE54D7510B2473573fF;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x2Bf62383a4A1349461bB744b4eC561338D8b4CF9;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -46,8 +46,8 @@ library DeploymentsRobinhoodMainnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x209504c3fB153a2e37690c30441eC67e909FE490;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x17d5e0776dafa4CAE8e6e1eBbf7278e1c4AF647f;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x66534bDE4f69F69342F929479797F7118B7ca74F;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0xF74aD241bDe9e2DAe7849D06ee4935731c1B5258;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/config/manifest.robinhood.testnet.sol
+++ b/src/config/manifest.robinhood.testnet.sol
@@ -32,11 +32,11 @@ library DeploymentsRobinhoodTestnet {
     address internal constant QUOTER = 0xaA9c5758D8E5804dbbC4c931C6EAf1Be68DD30CD;
 
     // --- Token implementations (cloned by factories) ---
-    address internal constant TOKEN_IMPL = 0x4B85Bd6406BE504832De9DeDe12ede7f08a72869;
-    address internal constant TAXABLE_TOKEN_V4_IMPL = 0x6382Aa066577Ff125CF67711aE859f351af1FFff;
+    address internal constant TOKEN_IMPL = 0xf68Ea9a3522647C58d7c77edE156cAA0930a7101;
+    address internal constant TAXABLE_TOKEN_V4_IMPL = 0x2aAE5BAa1FFE5a93a0feE92cb1d73FDA80120728;
 
     /// @notice V2 taxable token implementation (cloned by `LivoFactoryUniV2Unified` when tax is configured)
-    address internal constant TAXABLE_TOKEN_V2_IMPL = 0xcB5d351D5e418e832DB4F1d23E1D553C0DB643Ee;
+    address internal constant TAXABLE_TOKEN_V2_IMPL = 0x1f4F57DdCda5f2697899eEBe763682279b7aE39a;
 
     // --- Factories (unified) ---
     /// @notice UUPS proxy addresses that integrators whitelist. These stay stable across upgrades.
@@ -46,8 +46,8 @@ library DeploymentsRobinhoodTestnet {
     /// @notice Implementation addresses currently set behind the proxies above. Updated on every
     ///         `UpgradeUnifiedFactories` run. Tracked for Etherscan verification and audit trails;
     ///         no contract or frontend consumes these directly.
-    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0x48b3F72469cDba3986A36cE6C47e6Cb027dCCcF2;
-    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x974F9139D56DAE3D44714Cd24632BB9Bf69139E2;
+    address internal constant FACTORY_UNIV2_UNIFIED_IMPL = 0xBB0EBb375e9dc06DE3eC0d6410606Cb3DAc6737b;
+    address internal constant FACTORY_UNIV4_UNIFIED_IMPL = 0x23f1b9158071B651268c4A626808958E2DC63f02;
 
     // --- Creator vaults ---
     /// @notice `LivoCreatorVault` implementation cloned by the vault factory. Update after deploying.

--- a/src/tokens/SniperProtection.sol
+++ b/src/tokens/SniperProtection.sol
@@ -33,7 +33,7 @@ abstract contract SniperProtection {
     uint40 public constant ANTI_SNIPER_MAX_WINDOW = 1 days;
 
     /// @notice Max whitelist entries (includes the deployer if the dev opts to add it).
-    uint256 public constant MAX_WHITELISTED = 20;
+    uint256 public constant MAX_WHITELISTED = 50;
 
     /// @dev Mirrors `LivoToken.TOTAL_SUPPLY`; renamed to avoid a multiple-inheritance collision.
     /// @dev Caps are intentionally measured against the fixed total supply, NOT a token's


### PR DESCRIPTION
## What

Raises `MAX_WHITELISTED` in `SniperProtection` from **20 → 50**, so a token's anti-sniper config can whitelist up to 50 bypass addresses.

## Why

Requested increase to the anti-sniper whitelist cap in the `createToken` flow.

## Notes

- The creator-buy supply-receiver array (`SupplyShare[]`) was also in scope, but it has **no hard cap today** (only gas bounds it). Left uncapped per decision — no code change there.
- Tests read `MAX_WHITELISTED()` dynamically, so all 44 sniper-protection tests pass unchanged.
- Updated the two external integration docs that hardcoded `> 20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)